### PR TITLE
Kj 61 get dynamo db event data

### DIFF
--- a/src/app/apicall.service.ts
+++ b/src/app/apicall.service.ts
@@ -44,7 +44,7 @@ export class ApicallService {
       pipe(
         map((data) => {
           console.log(data);
-          console.log("getPopMovies() data.results: " + data.Items);
+          console.log("getPopMovies() data.Items: " + data.Items);
           return data.Items ?? [];
         })
       )
@@ -69,6 +69,18 @@ export class ApicallService {
         return JSON.parse(data.eventTitle);
       })
     )
+  }
+
+  // get Event data from DynamoDB
+  getMovieEvents() : Observable<MovieEvent[]> {
+    return this.http.get<MovieEvents>('https://ri86qpqtti.execute-api.us-west-2.amazonaws.com/movieevents-scan').
+      pipe(
+        map((data) => {
+          console.log(data);
+          console.log("getMovieEvents() data.Items: " + data.Items);
+          return data.Items ?? [];
+        })
+      )
   }
 
 }

--- a/src/app/event/event.component.html
+++ b/src/app/event/event.component.html
@@ -72,7 +72,7 @@
     <div fxLayout="row wrap" fxLayoutGap="16px grid">
       <div class="content" *ngFor="let movie of eventMovies">
         <app-movie-card [movie]="movie"> </app-movie-card>
-        <!--<h3>{{movie.title}}</h3>-->
+        <div class="movieTitle">{{movie.title}}</div>
       </div>
     </div>
   </div>

--- a/src/app/event/event.component.scss
+++ b/src/app/event/event.component.scss
@@ -13,6 +13,10 @@ mat-toolbar {
 
 .content {
   margin: 16px;
+  font-size: medium;
+  font-weight: bold;
+  padding: 20px;
+  overflow-wrap: normal;
 }
 
 .createBox p {
@@ -22,4 +26,11 @@ mat-toolbar {
 .confirmation {
   margin-left: 2em;
   font-size: 1.25rem;
+}
+
+.movieTitle {
+  font-size: medium;
+  font-weight: bold;
+  padding: 20px;
+  word-wrap: normal;
 }

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,5 +1,24 @@
 <h1>Your Events</h1>
 <a mat-raised-button color="primary" routerLink="/event">Build an Event</a>
-<div>
-  <a mat-raised-button color="accent" routerLink="/ranking">Event 1</a>
-</div>
+<a mat-raised-button color="accent" routerLink="/ranking">Event 1</a>
+
+<!-- TABLE TO DISPLAY CREATED EVENTS -->
+<div class="col-md-12">
+  <table class="table table-bordered">
+    <thead>
+      <tr>
+        <th scope="col">Host ID</th>
+        <th scope="col">Event Name</th>
+        <th scope="col">Date</th>
+        <!-- <th scope="col">Invitees Selected</th> -->
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let viewing of movieEvents">
+        <td>{{ viewing.hostID}}</td>
+        <td>{{ viewing.eventTitle }}</td>
+        <td>{{ viewing.eventDate }}</td>
+      </tr>
+    </tbody>
+  </table>
+

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,6 +1,9 @@
 <h1>Your Events</h1>
 <a mat-raised-button color="primary" routerLink="/event">Build an Event</a>
-<a mat-raised-button color="accent" routerLink="/ranking">Event 1</a>
+<h2>Click on a link below to go to your Events</h2>
+<div *ngFor="let ranking of movieEvents">
+  <a mat-raised-button color="warn" routerLink="/ranking">{{ranking.eventTitle}}</a>
+</div>
 
 <!-- TABLE TO DISPLAY CREATED EVENTS -->
 <div class="col-md-12">

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,4 +1,7 @@
 import { Component, OnInit } from '@angular/core';
+import { ApicallService } from '../apicall.service';
+import { HttpClient } from '@angular/common/http';
+import { MovieEvent } from '../event/event.component';
 
 @Component({
   selector: 'app-home',
@@ -7,9 +10,23 @@ import { Component, OnInit } from '@angular/core';
 })
 export class HomeComponent implements OnInit {
 
-  constructor() { }
+  movieEvents: MovieEvent[] = [];
+  demoID = "DEMO";
+  constructor(public apicall: ApicallService, private httpClient: HttpClient) { }
 
   ngOnInit(): void {
+    this.loadMovieEvents();
   }
 
+  loadMovieEvents() {
+    return this.apicall.getMovieEvents().subscribe((data) => {
+      console.log(data);
+      for (let index in data) {
+        if (data[index].hostID == this.demoID) {
+          this.movieEvents.push(data[index]);
+        }
+      }
+      console.log(this.movieEvents);
+      })
+  }
 }


### PR DESCRIPTION
Closes #61 #71 

# Description
As a USER, I want to be able to see the titles of movies below movie posters so it's easier to tell which movie I am looking at. As a USER, after I click the "Add Event" button, I want to see my new event on the Home page. For the purposes of testing, in order to artificially create the condition of only seeing the Events of the current Host, enter the value "DEMO" for the hostID when creating a new Event.

Event Page, movieCards have movie titles below them:
<img width="1293" alt="Screen Shot 2021-08-01 at 1 15 22 PM" src="https://user-images.githubusercontent.com/26866132/127784212-a76df389-628f-4fb6-b610-be8d16c3b95c.png">

Home Page, showing the Event data in a table and Event buttons that will in the future route to Event specific Ranking pages:
<img width="600" alt="Screen Shot 2021-08-01 at 1 14 38 PM" src="https://user-images.githubusercontent.com/26866132/127784221-247de979-8a09-41bc-afc7-3d8c884bbb02.png">

# Tested
Chrome browser on MacOS

# Testing
 - [ ] From current Home page, click the "Build Event" button.
 - [ ] Once movies load, enter in a hostID with a value of "DEMO".
 - [ ] Enter in a Event Title.
 - [ ] Select a Date from the datepicker.
 - [ ] View the movie titles below the movie posters.
 - [ ] Select at least two movies.
 - [ ] Click the "Add Event" button.
 - [ ] Navigate to Home page, and view all Events with the hostID with the value of "DEMO".
