### PR TITLE
Kj 79 specific ranking page routing

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -7,7 +7,7 @@ import { HomeComponent } from "./home/home.component";
 const routes: Routes = [
     { path: 'home', pathMatch: 'full', component: HomeComponent },
     { path: '', redirectTo: '/home', pathMatch: 'full' },
-    { path: 'ranking', pathMatch: 'full', component: RankingComponent },
+    { path: 'ranking/:eventID', component: RankingComponent },
     { path: 'event', component: EventComponent }
     /* add path for movie selection */
 ];

--- a/src/app/event/event.component.html
+++ b/src/app/event/event.component.html
@@ -72,7 +72,7 @@
     <div fxLayout="row wrap" fxLayoutGap="16px grid">
       <div class="content" *ngFor="let movie of eventMovies">
         <app-movie-card [movie]="movie"> </app-movie-card>
-        <div class="movieTitle">{{movie.title}}</div>
+        <div>{{movie.title}}</div>
       </div>
     </div>
   </div>

--- a/src/app/event/event.component.ts
+++ b/src/app/event/event.component.ts
@@ -20,6 +20,7 @@ export interface MovieEvents {
 }
 
 export interface MovieEvent {
+  id?: string;
   hostID: string;
   //eventID: string;
   eventTitle: string;

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,8 +1,8 @@
 <h1>Your Events</h1>
 <a mat-raised-button color="primary" routerLink="/event">Build an Event</a>
 <h2>Click on a link below to go to your Events</h2>
-<div *ngFor="let ranking of movieEvents">
-  <a mat-raised-button color="warn" routerLink="/ranking">{{ranking.eventTitle}}</a>
+<div *ngFor="let event of movieEvents">
+  <a mat-raised-button color="warn" routerLink="['/ranking', event.id]">{{event.eventTitle}}</a>
 </div>
 
 <!-- TABLE TO DISPLAY CREATED EVENTS -->

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -2,7 +2,7 @@
 <a mat-raised-button color="primary" routerLink="/event">Build an Event</a>
 <h2>Click on a link below to go to your Events</h2>
 <div *ngFor="let event of movieEvents">
-  <a mat-raised-button color="warn" routerLink="['/ranking', event.id]">{{event.eventTitle}}</a>
+  <a mat-raised-button color="warn" [routerLink]="['/ranking', event.id]">{{event.eventTitle}}</a>
 </div>
 
 <!-- TABLE TO DISPLAY CREATED EVENTS -->
@@ -10,6 +10,7 @@
   <table class="table table-bordered">
     <thead>
       <tr>
+        <th scope="col">Event ID</th>
         <th scope="col">Host ID</th>
         <th scope="col">Event Name</th>
         <th scope="col">Date</th>
@@ -18,6 +19,7 @@
     </thead>
     <tbody>
       <tr *ngFor="let viewing of movieEvents">
+        <td>{{ viewing.id}}</td>
         <td>{{ viewing.hostID}}</td>
         <td>{{ viewing.eventTitle }}</td>
         <td>{{ viewing.eventDate }}</td>

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -2,14 +2,13 @@ import { Component, OnInit } from '@angular/core';
 import { ApicallService } from '../apicall.service';
 import { HttpClient } from '@angular/common/http';
 import { MovieEvent } from '../event/event.component';
-
 @Component({
   selector: 'app-home',
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.scss']
 })
-export class HomeComponent implements OnInit {
 
+export class HomeComponent implements OnInit {
   movieEvents: MovieEvent[] = [];
   demoID = "DEMO";
   constructor(public apicall: ApicallService, private httpClient: HttpClient) { }

--- a/src/app/ranking/ranking.component.ts
+++ b/src/app/ranking/ranking.component.ts
@@ -5,6 +5,8 @@ import { OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { MovieItem, movielist } from '../movies';
 import { environment } from 'src/environments/environment';
+import { MovieEvent } from '../event/event.component';
+import { ActivatedRoute } from '@angular/router';
 
 /**
  * @title Drag&Drop custom preview
@@ -16,6 +18,7 @@ import { environment } from 'src/environments/environment';
 })
 
 export class RankingComponent implements OnInit {
+  event: MovieEvent | undefined;
   title = 'Movie ranking';
   Movie: MovieItem[] = [];
   value = '';
@@ -23,11 +26,17 @@ export class RankingComponent implements OnInit {
   movieRankings = new Map();
   highestRank = 'no highest rank';
 
-  constructor(public apicall: ApicallService, private router: Router) {
+  constructor(public apicall: ApicallService, private router: Router, private route: ActivatedRoute,) {
   }
 
   ngOnInit() {
     this.loadMovies();
+    // First get the event id from the current route.
+    const routeParams = this.route.snapshot.paramMap;
+    const eventIDFromRoute = Number(routeParams.get('EventID'));
+
+    // Find the event that correspond with the id provided in route.
+    //this.event = eventMovies.find((event) => event.id === eventIDFromRoute);
   }
 
   navigate() {


### PR DESCRIPTION
Closes #79 

# Description
As a USER, I want to be able to click on an Event button to take me to a page where I can rank movies.

Home page with Event ids and Buttons with Routing
<img width="736" alt="Screen Shot 2021-08-01 at 8 12 13 PM" src="https://user-images.githubusercontent.com/26866132/127806241-bdda706b-805f-45c8-8f61-09e78ec8fbf0.png">

Ranking page with Event id specific routing after clicking on Event button on Home page
<img width="833" alt="Screen Shot 2021-08-01 at 9 09 00 PM" src="https://user-images.githubusercontent.com/26866132/127806251-61ecf142-01b6-43db-9204-2992ac4309ac.png">

# Tested
Chrome browser on MacOS

# Testing
- [ ] View the Event IDs of the Event Names on the current Home page
- [ ] Click any of the Event buttons
- [ ] Check that the URL ending matches the Event ID of the Event Name on the Home page