### PR TITLE
Kj 80 event data in ranking

### DIFF
--- a/src/app/event/event.component.html
+++ b/src/app/event/event.component.html
@@ -43,7 +43,7 @@
 </div>
 
 <!-- TABLE TO DISPLAY CREATED EVENTS -->
-<div class="col-md-12">
+<!--<div class="col-md-12">
   <table class="table table-bordered">
     <thead>
       <tr>
@@ -51,7 +51,6 @@
         <th scope="col">Event Name</th>
         <th scope="col">Date</th>
         <th scope="col">Movies Selected</th>
-        <!-- <th scope="col">Invitees Selected</th> -->
       </tr>
     </thead>
     <tbody>
@@ -66,6 +65,7 @@
       </tr>
     </tbody>
   </table>
+</div>-->
 
   <!-- GRID TO DISPLAY MOVIES -->
   <div class="content">
@@ -76,4 +76,4 @@
       </div>
     </div>
   </div>
-</div>
+

--- a/src/app/event/event.component.ts
+++ b/src/app/event/event.component.ts
@@ -22,7 +22,6 @@ export interface MovieEvents {
 export interface MovieEvent {
   id?: string;
   hostID: string;
-  //eventID: string;
   eventTitle: string;
   eventDate: string;
   movies?: (PopMovieItem) [] | null;
@@ -54,7 +53,7 @@ export class EventComponent implements OnInit {
   date = new FormControl(new Date());
   gridColumns = 3;
 
-  constructor(public apicall: ApicallService, private httpClient: HttpClient, private eventService: EventService) {}
+  constructor(public apicall: ApicallService, private eventService: EventService, private httpClient: HttpClient) {}
 
   ngOnInit(): void {
     this.loadPopMovies();

--- a/src/app/event/event.component.ts
+++ b/src/app/event/event.component.ts
@@ -24,7 +24,7 @@ export interface MovieEvent {
   hostID: string;
   eventTitle: string;
   eventDate: string;
-  movies?: (PopMovieItem) [] | null;
+  eventMovies?: (PopMovieItem) [] | undefined;
   selectedMovies: PopMovieItem[];
   //invitees?: (EventInvitees) [] | null;
   //movieRankings?: (movieRankings) [] | null;
@@ -105,7 +105,6 @@ export class EventComponent implements OnInit {
     // Create newEvent object of MovieEvent type with the provided elements
     let newEvent: MovieEvent = {
       hostID: this.hostID,
-      //eventID : this.eventID,
       eventTitle : this.eventTitle,
       eventDate : this.eventDate,
       selectedMovies : [...this.eventService.getSelectedMovies()]

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -6,7 +6,7 @@
 </div>
 
 <!-- TABLE TO DISPLAY CREATED EVENTS -->
-<div class="col-md-12">
+<!--<div class="col-md-12">
   <table class="table table-bordered">
     <thead>
       <tr>
@@ -14,7 +14,6 @@
         <th scope="col">Host ID</th>
         <th scope="col">Event Name</th>
         <th scope="col">Date</th>
-        <!-- <th scope="col">Invitees Selected</th> -->
       </tr>
     </thead>
     <tbody>
@@ -26,4 +25,6 @@
       </tr>
     </tbody>
   </table>
+</div>-->
+
 

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -2,6 +2,8 @@ import { Component, OnInit } from '@angular/core';
 import { ApicallService } from '../apicall.service';
 import { HttpClient } from '@angular/common/http';
 import { MovieEvent } from '../event/event.component';
+import { RankingService } from '../ranking.service';
+
 @Component({
   selector: 'app-home',
   templateUrl: './home.component.html',
@@ -11,21 +13,12 @@ import { MovieEvent } from '../event/event.component';
 export class HomeComponent implements OnInit {
   movieEvents: MovieEvent[] = [];
   demoID = "DEMO";
-  constructor(public apicall: ApicallService, private httpClient: HttpClient) { }
+  constructor(public apicall: ApicallService, private rankingService: RankingService, private httpClient: HttpClient) { }
 
   ngOnInit(): void {
-    this.loadMovieEvents();
+    this.rankingService.loadMovieEventsByHostID(this.demoID);
+    this.movieEvents = this.rankingService.getMovieEvents();
+    // maybe take the assignment of the movieEvents out of ngOnInit, it is adding movies each time to the movieEvents variable
   }
 
-  loadMovieEvents() {
-    return this.apicall.getMovieEvents().subscribe((data) => {
-      console.log(data);
-      for (let index in data) {
-        if (data[index].hostID == this.demoID) {
-          this.movieEvents.push(data[index]);
-        }
-      }
-      console.log(this.movieEvents);
-      })
-  }
 }

--- a/src/app/movies.ts
+++ b/src/app/movies.ts
@@ -16,10 +16,10 @@ export interface Movies {
 
 export interface MovieItem {
     id: string;
-    resultType: string;
+    resultType?: string;
     image: string;
     title: string;
-    description: string;
+    description?: string;
 }
 
 export interface PopMovieItem {

--- a/src/app/ranking.service.ts
+++ b/src/app/ranking.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Movies, MovieItem, PopMovies, PopMovieItem } from './movies';
+import { MovieEvent } from './event/event.component';
+import { ApicallService } from './apicall.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class RankingService {
+  movieEvents: MovieEvent[] = [];
+  constructor(public apicall: ApicallService, private http: HttpClient) {}
+
+  loadMovieEventsByHostID(demoID: String) {
+    this.apicall.getMovieEvents().subscribe((data) => {
+      console.log(data);
+      for (let index in data) {
+        if (data[index].hostID == demoID) {
+          this.movieEvents.push(data[index]);
+        }
+      }
+      console.log(this.movieEvents);
+      })
+  }
+
+  getMovieEvents(){
+    return this.movieEvents;
+  }
+
+  getMovieEventByEventID(eventID: String){
+    return this.movieEvents.find(event => event.id == eventID);
+  }
+}
+

--- a/src/app/ranking.service.ts
+++ b/src/app/ranking.service.ts
@@ -15,7 +15,8 @@ export class RankingService {
     this.apicall.getMovieEvents().subscribe((data) => {
       console.log(data);
       for (let index in data) {
-        if (data[index].hostID == demoID) {
+        // make sure the hostID equals the demoID, and that the id does not already exist in the movieEvents array
+       if ((data[index].hostID == demoID) && (data[index].id != (this.movieEvents.find(event => event.id == data[index].id))?.id)) {
           this.movieEvents.push(data[index]);
         }
       }

--- a/src/app/ranking/ranking.component.html
+++ b/src/app/ranking/ranking.component.html
@@ -1,3 +1,6 @@
+<h1>Event: {{ eventTitle }}</h1>
+<h2>Event Date: {{ eventDate }}</h2>
+
 <p>
   <mat-form-field appearance="fill">
     <mat-label>Enter User ID</mat-label>
@@ -11,7 +14,11 @@
 </p>
 <h3>User ID: {{ userID }}</h3>
 
-<h1>Rank the Movies!</h1>
+<h3 style="color: red">
+  {{ errorMsg }}
+</h3>
+
+<h2>Rank the Movies!</h2>
 <p>
   First choice goes on the top of the list, last choice goes on the bottom of
   the list
@@ -25,14 +32,14 @@
         ? "Loading..."
         : movieItemArray.length === 0
         ? "No results"
-        : movieItemArray[0].title + " " + " id: " + movieItemArray[0].id
+        : movieItemArray[0].title 
     }}
   </h2>
 </div>
 
 <div cdkDropList class="example-list" (cdkDropListDropped)="drop($event)">
   <div class="example-box" *ngFor="let movie of movieItemArray" cdkDrag>
-    {{ movie.title }} id: {{ movie.id }}
+    {{ movie.title }} 
     <img *cdkDragPreview [src]="movie.image" [alt]="movie.title" />
   </div>
 </div>

--- a/src/app/ranking/ranking.component.html
+++ b/src/app/ranking/ranking.component.html
@@ -21,18 +21,18 @@
   <h2>
     Top Choice:
     {{
-      Movie === undefined
+      movieItemArray === undefined
         ? "Loading..."
-        : Movie.length === 0
+        : movieItemArray.length === 0
         ? "No results"
-        : Movie[0].title + " " + Movie[0].description + " id: " + Movie[0].id
+        : movieItemArray[0].title + " " + " id: " + movieItemArray[0].id
     }}
   </h2>
 </div>
 
 <div cdkDropList class="example-list" (cdkDropListDropped)="drop($event)">
-  <div class="example-box" *ngFor="let movie of Movie" cdkDrag>
-    {{ movie.title }} {{ movie.description }} id: {{ movie.id }}
+  <div class="example-box" *ngFor="let movie of movieItemArray" cdkDrag>
+    {{ movie.title }} id: {{ movie.id }}
     <img *cdkDragPreview [src]="movie.image" [alt]="movie.title" />
   </div>
 </div>

--- a/src/app/ranking/ranking.component.ts
+++ b/src/app/ranking/ranking.component.ts
@@ -20,10 +20,13 @@ import { RankingService } from '../ranking.service';
 
 export class RankingComponent implements OnInit {
   event: MovieEvent | undefined;
+  eventTitle = '';
+  eventDate = '';
   title = 'Movie ranking';
   movieItemArray: (MovieItem) [] | undefined;
   value = '';
-  userID = 'no User ID entered';
+  userID = 'No User ID Entered';
+  errorMsg = '';
   movieRankings = new Map();
   highestRank = 'no highest rank';
   movieEvent: MovieEvent | undefined;
@@ -47,27 +50,11 @@ export class RankingComponent implements OnInit {
   loadMoviesFromEvent() {
     // if movieEvent is not undefined or null, assign movies to movieItemArray
     if (this.movieEvent != undefined) {
-      console.log("event title: " + this.movieEvent.eventTitle);
-      console.log("event date: " + this.movieEvent.eventDate);
-      console.log("event movies array: " + this.movieEvent.eventMovies);
+      this.eventTitle = this.movieEvent.eventTitle;
+      this.eventDate = this.movieEvent.eventDate;
       this.movieItemArray = this.movieEvent.eventMovies;
     }
   }
-  /*
-  loadMovies() {
-    if (environment.production === false) {
-      this.Movie = <MovieItem[]>movielist
-      console.log("fake array: " + JSON.stringify(this.Movie));
-      return this.Movie;
-    } else {
-    return this.apicall.getMovies("Star Wars").subscribe((data) => {
-      this.Movie = data;
-      console.log(data);
-      console.log(this.Movie[0]);
-      })
-    }
-  }
-  */
 
   drop(event: CdkDragDrop<{ title: string, image: string }[]>) {
     if (this.movieItemArray) {
@@ -76,7 +63,13 @@ export class RankingComponent implements OnInit {
   }
 
   submitUserID() {
-    this.userID = this.value;
+    if (this.value == '') {
+      this.errorMsg = 'You must enter a User ID.';
+      return;
+    } else {
+      this.userID = this.value;
+      this.errorMsg = '';
+    }
     console.log("User ID: " + this.userID);
   }
 
@@ -111,11 +104,14 @@ export class RankingComponent implements OnInit {
   }
 
   submitRanking() {
+    if (this.userID == '' || this.userID == 'No User ID Entered') {
+      this.errorMsg = 'You must enter a User ID.';
+      return;
+    }
     this.rankMovies();
     console.log("Highest rank: " + this.highestRank);
 
     console.log("User ID: " + this.userID);
-
     for (let entry of this.movieRankings.entries()) {
       console.log(entry[0], entry[1]);
     }

--- a/src/app/ranking/ranking.component.ts
+++ b/src/app/ranking/ranking.component.ts
@@ -3,7 +3,7 @@ import {CdkDragDrop, moveItemInArray} from '@angular/cdk/drag-drop';
 import { ApicallService } from '../apicall.service';
 import { OnInit } from '@angular/core';
 import { Router } from '@angular/router';
-import { MovieItem, movielist } from '../movies';
+import { MovieItem, movielist, PopMovieItem } from '../movies';
 import { environment } from 'src/environments/environment';
 import { MovieEvent } from '../event/event.component';
 import { ActivatedRoute } from '@angular/router';
@@ -21,7 +21,7 @@ import { RankingService } from '../ranking.service';
 export class RankingComponent implements OnInit {
   event: MovieEvent | undefined;
   title = 'Movie ranking';
-  Movie: MovieItem[] = [];
+  movieItemArray: (MovieItem) [] | undefined;
   value = '';
   userID = 'no User ID entered';
   movieRankings = new Map();
@@ -34,21 +34,26 @@ export class RankingComponent implements OnInit {
   ngOnInit() {
     // First get the event id from the current route.
     const routeParams = this.route.snapshot.paramMap;
-    //console.log(routeParams);
     const eventIDFromRoute = String(routeParams.get('eventID'));
     console.log("eventIDFromRoute: " + eventIDFromRoute);
 
     // Find the event that correspond with the id provided in route.
     this.movieEvent = JSON.parse(JSON.stringify(this.rankingService.getMovieEventByEventID(eventIDFromRoute)));
+    //this.movieEvent = this.rankingService.getMovieEventByEventID(eventIDFromRoute);
     console.log("movieEvent: " + JSON.stringify(this.movieEvent));
-    // the methods to get the movieEvent aren't firing again if returning to the same page, figure out where to put these method calls instead
+    this.loadMoviesFromEvent();
   }
 
+  loadMoviesFromEvent() {
+    // if movieEvent is not undefined or null, assign movies to movieItemArray
+    if (this.movieEvent != undefined) {
+      console.log("event title: " + this.movieEvent.eventTitle);
+      console.log("event date: " + this.movieEvent.eventDate);
+      console.log("event movies array: " + this.movieEvent.eventMovies);
+      this.movieItemArray = this.movieEvent.eventMovies;
+    }
+  }
   /*
-  navigate() {
-    this.router.navigateByUrl('/events');
-  }
-
   loadMovies() {
     if (environment.production === false) {
       this.Movie = <MovieItem[]>movielist
@@ -65,7 +70,9 @@ export class RankingComponent implements OnInit {
   */
 
   drop(event: CdkDragDrop<{ title: string, image: string }[]>) {
-    moveItemInArray(this.Movie, event.previousIndex, event.currentIndex);
+    if (this.movieItemArray) {
+    moveItemInArray(this.movieItemArray, event.previousIndex, event.currentIndex);
+    }
   }
 
   submitUserID() {
@@ -74,15 +81,17 @@ export class RankingComponent implements OnInit {
   }
 
   rankMovies() {
-    let points = this.Movie.length
-    for (let i = 0; i < this.Movie.length; i++) {
-      if (this.movieRankings.has(this.Movie[i].title)) {
-        let newRanking = points + this.movieRankings.get(this.Movie[i].title)
-        this.movieRankings.set(this.Movie[i].title, newRanking);
-        points--;
-      } else {
-        this.movieRankings.set(this.Movie[i].title, points);
-        points--;
+    if (this.movieItemArray) {
+      let points = this.movieItemArray.length
+      for (let i = 0; i < this.movieItemArray.length; i++) {
+        if (this.movieRankings.has(this.movieItemArray[i].title)) {
+          let newRanking = points + this.movieRankings.get(this.movieItemArray[i].title)
+          this.movieRankings.set(this.movieItemArray[i].title, newRanking);
+          points--;
+        } else {
+          this.movieRankings.set(this.movieItemArray[i].title, points);
+          points--;
+        }
       }
     }
     this.findTopMovie();

--- a/src/app/ranking/ranking.component.ts
+++ b/src/app/ranking/ranking.component.ts
@@ -39,7 +39,7 @@ export class RankingComponent implements OnInit {
     console.log("eventIDFromRoute: " + eventIDFromRoute);
 
     // Find the event that correspond with the id provided in route.
-    this.movieEvent = this.rankingService.getMovieEventByEventID(eventIDFromRoute);
+    this.movieEvent = JSON.parse(JSON.stringify(this.rankingService.getMovieEventByEventID(eventIDFromRoute)));
     console.log("movieEvent: " + JSON.stringify(this.movieEvent));
     // the methods to get the movieEvent aren't firing again if returning to the same page, figure out where to put these method calls instead
   }

--- a/src/app/ranking/ranking.component.ts
+++ b/src/app/ranking/ranking.component.ts
@@ -7,6 +7,7 @@ import { MovieItem, movielist } from '../movies';
 import { environment } from 'src/environments/environment';
 import { MovieEvent } from '../event/event.component';
 import { ActivatedRoute } from '@angular/router';
+import { RankingService } from '../ranking.service';
 
 /**
  * @title Drag&Drop custom preview
@@ -25,20 +26,25 @@ export class RankingComponent implements OnInit {
   userID = 'no User ID entered';
   movieRankings = new Map();
   highestRank = 'no highest rank';
+  movieEvent: MovieEvent | undefined;
 
-  constructor(public apicall: ApicallService, private router: Router, private route: ActivatedRoute,) {
+  constructor(public apicall: ApicallService, private rankingService: RankingService, private router: Router, private route: ActivatedRoute,) {
   }
 
   ngOnInit() {
-    this.loadMovies();
     // First get the event id from the current route.
     const routeParams = this.route.snapshot.paramMap;
-    const eventIDFromRoute = Number(routeParams.get('EventID'));
+    //console.log(routeParams);
+    const eventIDFromRoute = String(routeParams.get('eventID'));
+    console.log("eventIDFromRoute: " + eventIDFromRoute);
 
     // Find the event that correspond with the id provided in route.
-    //this.event = eventMovies.find((event) => event.id === eventIDFromRoute);
+    this.movieEvent = this.rankingService.getMovieEventByEventID(eventIDFromRoute);
+    console.log("movieEvent: " + JSON.stringify(this.movieEvent));
+    // the methods to get the movieEvent aren't firing again if returning to the same page, figure out where to put these method calls instead
   }
 
+  /*
   navigate() {
     this.router.navigateByUrl('/events');
   }
@@ -56,6 +62,7 @@ export class RankingComponent implements OnInit {
       })
     }
   }
+  */
 
   drop(event: CdkDragDrop<{ title: string, image: string }[]>) {
     moveItemInArray(this.Movie, event.previousIndex, event.currentIndex);


### PR DESCRIPTION
Closes #80 

# Description
As a USER, I want to be able to rank movies based on movies selected for ranking in the "Build an Event" page. The information pulled from the Build an Event page is pulled into the Ranking page by matching the unique ids of the Events. As a USER, I want to be able to see a visual warning that I haven't entered a user ID before clicking the submit button. 

Image showing the movie event id matches the URL of the Ranking page: 
<img width="1457" alt="Screen Shot 2021-08-04 at 8 42 19 PM" src="https://user-images.githubusercontent.com/26866132/128287661-aeb09d9c-f7f3-45de-a1d7-76f283dfa205.png">

Images showing the visual warning that a User ID hasn't been submitted:
<img width="905" alt="Screen Shot 2021-08-04 at 8 59 51 PM" src="https://user-images.githubusercontent.com/26866132/128289034-746db13c-b8b2-4ea5-a973-b0093eeadc90.png">

# Tested
Chrome browser on MacOS

# Testing
- [ ] Click on any of the Event buttons on the current Home page.
- [ ] View the ending of the URL of the Ranking page.
- [ ] Open the console and view the Event id, and see that it matches the end of the URL of the Ranking page.
- [ ] VIew the movie titles in the console and see that it matches the movie titles in the drag and drop.
- [ ] Click on the "Submit" button
- [ ] View the warning about submitting without a User ID
- [ ] Enter an empty string into the User ID Form Field
- [ ] View the warning about submitting without a User ID
- [ ] Enter a non-empty String into the User ID Form Field
- [ ] View the submitted User ID
- [ ] Click on the "Submit" button
- [ ] View the submitted information in the console