### PR TITLE
Mg 81 ranked movies to event table

### DIFF
--- a/src/app/apicall.service.ts
+++ b/src/app/apicall.service.ts
@@ -74,13 +74,13 @@ export class ApicallService {
   }
 
   // Add user SelectedRankings to the indicated eventid in the DynamoDb Event table
-  addUserRankings(body: RankUpdate) /*: Observable<UserRankings[]> */ {
+  addUserRankings(body: RankUpdate): Observable<RankUpdate> /*: Observable<UserRankings[]> */ {
     const headers = new HttpHeaders()
       headers.append('Origin','http://localhost:4200')
       .append("Accept", "appliction/json")
       .append("Content-Type", "application/json");
 
-    return this.http.put<[]>('https://ri86qpqtti.execute-api.us-west-2.amazonaws.com/user-rankings', body, { 'headers': headers })  
+    return this.http.put<RankUpdate>('https://ri86qpqtti.execute-api.us-west-2.amazonaws.com/user-rankings', body, { 'headers': headers })  
   }
 
   // get Event data from DynamoDB

--- a/src/app/apicall.service.ts
+++ b/src/app/apicall.service.ts
@@ -6,6 +6,7 @@ import { from, Observable, throwError } from 'rxjs';
 import { map, catchError } from 'rxjs/operators';
 import { environment } from "../environments/environment";
 import { MovieEvents, MovieEvent } from "../app/event/event.component";
+import { UserRankings, RankUpdate } from '../app/ranking/ranking.component';
 
 interface ItemsResponse {
   movies: Array<Movies>;
@@ -73,13 +74,13 @@ export class ApicallService {
   }
 
   // Add user SelectedRankings to the indicated eventid in the DynamoDb Event table
-  addUserRankings(/* (body: UserRanking) : Observable<UserRanking[]> */) {
+  addUserRankings(body: RankUpdate) /*: Observable<UserRankings[]> */ {
     const headers = new HttpHeaders()
       headers.append('Origin','http://localhost:4200')
       .append("Accept", "appliction/json")
       .append("Content-Type", "application/json");
 
-    //return this.http.put<UserRanking>('https://ri86qpqtti.execute-api.us-west-2.amazonaws.com/events/rankings', body, { 'headers': headers })  
+    return this.http.put<[]>('https://ri86qpqtti.execute-api.us-west-2.amazonaws.com/user-rankings', body, { 'headers': headers })  
   }
 
   // get Event data from DynamoDB

--- a/src/app/apicall.service.ts
+++ b/src/app/apicall.service.ts
@@ -50,6 +50,7 @@ export class ApicallService {
       )
   }
 
+  // adds created event to the Event DynamoDB table
   addMovieEvent(body: MovieEvent) : Observable<MovieEvent[]> {
     const headers = new HttpHeaders()
     /* .set('content-type', 'application/json')
@@ -69,6 +70,16 @@ export class ApicallService {
         return JSON.parse(data.eventTitle);
       })
     )
+  }
+
+  // Add user SelectedRankings to the indicated eventid in the DynamoDb Event table
+  addUserRankings(/* (body: UserRanking) : Observable<UserRanking[]> */) {
+    const headers = new HttpHeaders()
+      headers.append('Origin','http://localhost:4200')
+      .append("Accept", "appliction/json")
+      .append("Content-Type", "application/json");
+
+    //return this.http.put<UserRanking>('https://ri86qpqtti.execute-api.us-west-2.amazonaws.com/events/rankings', body, { 'headers': headers })  
   }
 
   // get Event data from DynamoDB

--- a/src/app/apicall.service.ts
+++ b/src/app/apicall.service.ts
@@ -6,7 +6,7 @@ import { from, Observable, throwError } from 'rxjs';
 import { map, catchError } from 'rxjs/operators';
 import { environment } from "../environments/environment";
 import { MovieEvents, MovieEvent } from "../app/event/event.component";
-import { UserRankings, RankUpdate } from '../app/ranking/ranking.component';
+import { RankUpdate } from '../app/ranking/ranking.component';
 
 interface ItemsResponse {
   movies: Array<Movies>;
@@ -74,7 +74,7 @@ export class ApicallService {
   }
 
   // Add user SelectedRankings to the indicated eventid in the DynamoDb Event table
-  addUserRankings(body: RankUpdate): Observable<RankUpdate> /*: Observable<UserRankings[]> */ {
+  addUserRankings(body: RankUpdate): Observable<RankUpdate> {
     const headers = new HttpHeaders()
       headers.append('Origin','http://localhost:4200')
       .append("Accept", "appliction/json")

--- a/src/app/event/event.component.ts
+++ b/src/app/event/event.component.ts
@@ -24,7 +24,7 @@ export interface MovieEvent {
   hostID: string;
   eventTitle: string;
   eventDate: string;
-  eventMovies?: (PopMovieItem) [] | undefined;
+  eventMovies?: (PopMovieItem) [];
   selectedMovies: PopMovieItem[];
   //invitees?: (EventInvitees) [] | null;
   //movieRankings?: (movieRankings) [] | null;

--- a/src/app/movies.ts
+++ b/src/app/movies.ts
@@ -23,6 +23,7 @@ export interface MovieItem {
 }
 
 export interface PopMovieItem {
+    points?: number
     id: string;
     rank: number;
     rankUpDown: string;

--- a/src/app/movies.ts
+++ b/src/app/movies.ts
@@ -84,6 +84,69 @@ export const movielist = [
         }
 ]
 
+export const popMovieSamples = [
+        {
+        id: "tt3480822",
+        rank: "1",
+        rankUpDown: "+1",
+        title: "Black Widow",
+        fullTitle: "Black Widow (2021)",
+        year: "2021",
+        image: "https://imdb-api.com/images/original/MV5BNjRmNDI5MjMtMmFhZi00YzcwLWI4ZGItMGI2MjI0N2Q3YmIwXkEyXkFqcGdeQXVyMTkxNjUyNQ@@._V1_Ratio0.6716_AL_.jpg",
+        crew: "Cate Shortland (dir.), Scarlett Johansson, Florence Pugh",
+        imDbRating: "6.9",
+        imDbRatingCount: "111665"
+        },
+        {
+        id: "tt3554046",
+        rank: "2",
+        rankUpDown: "+29",
+        title: "Space Jam: A New Legacy",
+        fullTitle: "Space Jam: A New Legacy (2021)",
+        year: "2021",
+        image: "https://imdb-api.com/images/original/MV5BZTAzN2ZlZTEtOTA5ZS00MGFjLTliYWMtYTQzYTFlYTIwZDVmXkEyXkFqcGdeQXVyNjY1MTg4Mzc@._V1_Ratio0.6716_AL_.jpg",
+        crew: "Malcolm D. Lee (dir.), LeBron James, Don Cheadle",
+        imDbRating: "4.3",
+        imDbRatingCount: "19472"
+        },
+        {
+        id: "tt9777666",
+        rank: "3",
+        rankUpDown: "-2",
+        title: "The Tomorrow War",
+        fullTitle: "The Tomorrow War (2021)",
+        year: "2021",
+        image: "https://imdb-api.com/images/original/MV5BNTI2YTI0MWEtNGQ4OS00ODIzLWE1MWEtZGJiN2E3ZmM1OWI1XkEyXkFqcGdeQXVyODk4OTc3MTY@._V1_Ratio0.6716_AL_.jpg",
+        crew: "Chris McKay (dir.), Chris Pratt, Yvonne Strahovski",
+        imDbRating: "6.6",
+        imDbRatingCount: "104077"
+        },
+        {
+        id: "tt9701940",
+        rank: "4",
+        rankUpDown: "+2",
+        title: "Fear Street: Part Two - 1978",
+        fullTitle: "Fear Street: Part Two - 1978 (2021)",
+        year: "2021",
+        image: "https://imdb-api.com/images/original/MV5BOTQxMWNiZmYtOGUzMi00OGU5LTkzMjctYWY4ZmJkZjZiYWI5XkEyXkFqcGdeQXVyMDM2NDM2MQ@@._V1_Ratio0.6716_AL_.jpg",
+        crew: "Leigh Janiak (dir.), Sadie Sink, Emily Rudd",
+        imDbRating: "6.8",
+        imDbRatingCount: "21949"
+        },
+        {
+        id: "tt6566576",
+        rank: "5",
+        rankUpDown: "-2",
+        title: "Fear Street: Part One - 1994",
+        fullTitle: "Fear Street: Part One - 1994 (2021)",
+        year: "2021",
+        image: "https://imdb-api.com/images/original/MV5BNzQzYjIyZDQtMjBhZS00MzU3LTk0MTQtNTVmMDI3ZWY0ZWU3XkEyXkFqcGdeQXVyMTkxNjUyNQ@@._V1_Ratio0.6716_AL_.jpg",
+        crew: "Leigh Janiak (dir.), Kiana Madeira, Olivia Scott Welch",
+        imDbRating: "6.2",
+        imDbRatingCount: "34917"
+        }
+]
+
 // For PopMovieItems
 export const popMovielist = [
     {

--- a/src/app/ranking/ranking.component.html
+++ b/src/app/ranking/ranking.component.html
@@ -1,15 +1,12 @@
 <p>
   <mat-form-field appearance="fill">
     <mat-label>Enter User ID</mat-label>
-    <input
-      matInput
-      type="text"
-      [(ngModel)]="value"
-      (keyup.enter)="submitUserID()"
-    />
+    <input matInput type="text" [(ngModel)]="userID" />
   </mat-form-field>
 </p>
-<h3>User ID: {{ userID }}</h3>
+<h3>EventTitle: {{ eventTitle === "" ? "No Title found" : eventTitle }}</h3>
+<h3>EventDate: {{ eventDate === "" ? "No Date found" : eventDate }}</h3>
+<h3>User ID: {{ userID === "" ? "No User ID entered" : userID }}</h3>
 
 <h1>Rank the Movies!</h1>
 <p>
@@ -19,20 +16,21 @@
 
 <div>
   <h2>
-    Top Choice:
+    {{ userID === "" ? "Your" : userID + "'s" }} Current Top Choice:
     {{
-      Movie === undefined
+      movie === undefined
         ? "Loading..."
-        : Movie.length === 0
+        : movie.length === 0
         ? "No results"
-        : Movie[0].title + " " + Movie[0].description + " id: " + Movie[0].id
+        : movie[0].title + " " + ", id: " + movie[0].id
     }}
   </h2>
 </div>
 
+<!-- Adjust this so they are dragging movie posters? -->
 <div cdkDropList class="example-list" (cdkDropListDropped)="drop($event)">
-  <div class="example-box" *ngFor="let movie of Movie" cdkDrag>
-    {{ movie.title }} {{ movie.description }} id: {{ movie.id }}
+  <div class="example-box" *ngFor="let movie of movie" cdkDrag>
+    {{ movie.title }} id: {{ movie.id }}
     <img *cdkDragPreview [src]="movie.image" [alt]="movie.title" />
   </div>
 </div>
@@ -41,4 +39,4 @@
   Submit
 </button>
 
-<h1>Current Highest Rank: {{ highestRank }}</h1>
+<!-- <h1>Current Highest Rank: {{ highestRank }}</h1> -->

--- a/src/app/ranking/ranking.component.html
+++ b/src/app/ranking/ranking.component.html
@@ -4,7 +4,7 @@
 <p>
   To invite someone to rank the movies, either
   <a
-    href="mailto:?subject={{ eventTitle }}?body=Before%20{{
+    href="mailto:?subject={{ eventTitle }}&body=Before%20{{
       eventDate
     }},%20rank%20the%20movies%20at:%0A%0A{{ url }}%0A%0AThanks!"
   >
@@ -19,8 +19,7 @@
     <input matInput type="text" [(ngModel)]="userID" />
   </mat-form-field>
 </p>
-<h3>EventTitle: {{ eventTitle === "" ? "No Title found" : eventTitle }}</h3>
-<h3>EventDate: {{ eventDate === "" ? "No Date found" : eventDate }}</h3>
+
 <h3>User ID: {{ userID === "" ? "No User ID entered" : userID }}</h3>
 
 <h3 style="color: red">

--- a/src/app/ranking/ranking.component.ts
+++ b/src/app/ranking/ranking.component.ts
@@ -49,7 +49,7 @@ export class RankingComponent implements OnInit {
 
   movieEvent: MovieEvent[] = []; // the event info the ranking is for
   movie: PopMovieItem[] = []; 
-  id = '3u0lmogh79d';   // the movies to be ranked (from event) -- does this need to be separate?
+  id = 'euef0q95jh8';   // the movies to be ranked (from event) -- does this need to be separate?
   value = '';
   eventTitle = '';
   eventDate = '';

--- a/src/app/ranking/ranking.component.ts
+++ b/src/app/ranking/ranking.component.ts
@@ -149,11 +149,12 @@ export class RankingComponent implements OnInit {
       userID: this.userID,
       rankings: this.userRankings
     }
+    
     console.log('rankingUpdate: ' + JSON.stringify(rankingUpdate));
     console.log(typeof(rankingUpdate));
     console.log('rankings: ' + JSON.stringify(rankingUpdate.rankings));
     // THEN invoke apicall to put rankings into the DB.
-    this.apicall.addUserRankings(rankingUpdate).subscribe();
+    this.apicall.addUserRankings(rankingUpdate).subscribe(data => console.log(data));
   }
 
 }

--- a/src/app/ranking/ranking.component.ts
+++ b/src/app/ranking/ranking.component.ts
@@ -10,20 +10,6 @@ import { MovieEvent } from '../event/event.component';
 import { ActivatedRoute } from '@angular/router';
 import { RankingService } from '../ranking.service';
 
-//userrankings object--like movieEvent object, with array of popmovies, plus a score attribute
-export interface UserRank {
-  searchType: string;
-  expression: string;
-  Items?: (UserRankings)[] | null;
-  errorMessage: string;
-}
-
-export interface UserRankings {
-    id: string;
-    title: string;
-    image: string;
-    points?: number;
-}
 
 export interface RankUp {
   searchType: string;
@@ -34,7 +20,7 @@ export interface RankUp {
 export interface RankUpdate {
   eventID: string;
   userID: string;
-  rankings: Map<string, number>;
+  rankings: (PopMovieItem)[] | undefined;
 }
 
 /**
@@ -47,21 +33,15 @@ export interface RankUpdate {
 })
 
 export class RankingComponent implements OnInit {
-  event: MovieEvent | undefined;
   id = '';
   eventTitle = '';
   eventDate = '';
   value = '';
-  userID = 'No User ID Entered';
+  userID = '';
   title = 'Movie ranking';
-  movieItemArray: (MovieItem) [] | undefined;
-  userRankings: (MovieItem)[] | undefined;
+  movieItemArray: (PopMovieItem)[] | undefined;
   movieRankings = new Map();
   errorMsg = '';
-
-
-  //movie: PopMovieItem[] = []; 
-  //id = 'euef0q95jh8';   // the movies to be ranked (from event) -- does this need to be separate?
 
   highestRank = 'no highest rank';
   movieEvent: MovieEvent | undefined;
@@ -89,8 +69,7 @@ export class RankingComponent implements OnInit {
       this.eventTitle = this.movieEvent.eventTitle;
       this.eventDate = this.movieEvent.eventDate;
       this.movieItemArray = this.movieEvent.eventMovies;
-      this.userRankings = this.movieEvent.eventMovies;
-      //this.userRankings = <UserRankings[]><unknown>popMovieSamples;
+      
       if (this.movieEvent.id) {
         this.id = this.movieEvent.id;
         this.url = this.url + this.id;
@@ -125,11 +104,9 @@ if (this.movieItemArray) {
         points--;
       } else {
         this.movieRankings.set(this.movieItemArray[i].title, points);
-        //this.movieRankings.set(this.userRankings[i].title, points);
 
-        // Adds points attribute with the value determined to the movie in userRankings array
-        //let movieIndex = this.userRankings.findIndex(x => x.title === this.movieItemArray[i].title);
-        //this.userRankings[movieIndex].points = points;
+        // Adds points attribute with the value determined to the movie in movieItemArray
+        this.movieItemArray[i].points = points;
         points--;
       }
       }
@@ -162,22 +139,20 @@ if (this.movieItemArray) {
     for (let entry of this.movieRankings.entries()) {
       console.log('movie title: ' + entry[0])
       console.log('points: ' + entry[1]);
-      //find title in UserRankings array and update points?
-      //this.userRankings.find(x => x.title === entry[0])
     }
-    console.log(this.userRankings);
-    console.log(typeof(this.userRankings));
 
-    // Still need to figure out how to target the movieEvent.id
+
+    
     let rankingUpdate: RankUpdate = {
-      eventID: this.id, //this.movieEvent[0].id,
+      eventID: this.id,
       userID: this.userID,
-      rankings: this.movieRankings
+      rankings: this.movieItemArray
     }
     
     console.log('rankingUpdate: ' + JSON.stringify(rankingUpdate));
     console.log(typeof(rankingUpdate));
     console.log('rankings: ' + JSON.stringify(rankingUpdate.rankings));
+
     // THEN invoke apicall to put rankings into the DB.
     this.apicall.addUserRankings(rankingUpdate).subscribe(data => console.log(data));
   }

--- a/src/app/ranking/ranking.component.ts
+++ b/src/app/ranking/ranking.component.ts
@@ -8,6 +8,33 @@ import { environment } from 'src/environments/environment';
 import { HttpClient } from '@angular/common/http';
 import { MovieEvent } from '../event/event.component';
 
+//userrankings object--like movieEvent object, with array of popmovies, plus a score attribute
+export interface UserRank {
+  searchType: string;
+  expression: string;
+  Items?: (UserRankings)[] | null;
+  errorMessage: string;
+}
+
+export interface UserRankings {
+    id: string;
+    title: string;
+    image: string;
+    points?: number;
+}
+
+export interface RankUp {
+  searchType: string;
+  expression: string;
+  Items?: (RankUpdate)[] | null;
+  errorMessage: string;
+}
+export interface RankUpdate {
+  eventID: string;
+  userID: string;
+  rankings: (UserRankings)[];
+}
+
 /**
  * @title Drag&Drop custom preview
  */
@@ -21,11 +48,13 @@ export class RankingComponent implements OnInit {
   title = 'Movie ranking';
 
   movieEvent: MovieEvent[] = []; // the event info the ranking is for
-  movie: PopMovieItem[] = [];    // the movies to be ranked (from event) -- does this need to be separate?
+  movie: PopMovieItem[] = []; 
+  id = 'testid';   // the movies to be ranked (from event) -- does this need to be separate?
   value = '';
   eventTitle = '';
   eventDate = '';
   userID = '';
+  userRankings: UserRankings[] = [];
   movieRankings = new Map();  // 
   highestRank = 'no highest rank';
 
@@ -45,6 +74,7 @@ export class RankingComponent implements OnInit {
   loadMovies() {
     if (environment.production === false) {
       this.movie = <PopMovieItem[]><unknown>popMovieSamples
+      this.userRankings = <PopMovieItem[]><unknown>popMovieSamples;
       console.log("fake array: " + JSON.stringify(this.movie));
       return this.movie;
     } else {
@@ -74,6 +104,10 @@ export class RankingComponent implements OnInit {
         points--;
       } else {
         this.movieRankings.set(this.movie[i].title, points);
+
+        // Adds points attribute with the value determined to the movie in userRankings array
+        let movieIndex = this.userRankings.findIndex(x => x.title === this.movie[i].title);
+        this.userRankings[movieIndex].points = points;
         points--;
       }
     }
@@ -95,15 +129,28 @@ export class RankingComponent implements OnInit {
 
   submitRanking() {
     this.rankMovies(); 
-    // THEN invoke apicall to put rankings into the DB.
     
     console.log("Highest rank: " + this.highestRank);
 
     console.log("User ID: " + this.userID);
 
     for (let entry of this.movieRankings.entries()) {
-      console.log(entry[0], entry[1]);
+      console.log('movie title: ' + entry[0])
+      console.log('points: ' + entry[1]);
+      //find title in UserRankings array and update points?
+      //this.userRankings.find(x => x.title === entry[0])
     }
+    console.log(this.userRankings);
+
+    // Still need to figure out how to target the movieEvent.id
+    let rankingUpdate: RankUpdate = {
+      eventID: this.id, //this.movieEvent[0].id,
+      userID: this.userID,
+      rankings: this.userRankings
+    }
+    console.log('rankingUpdate: ' + JSON.stringify(rankingUpdate));
+    // THEN invoke apicall to put rankings into the DB.
+    this.apicall.addUserRankings(rankingUpdate).subscribe();
   }
 
 }

--- a/src/app/ranking/ranking.component.ts
+++ b/src/app/ranking/ranking.component.ts
@@ -149,6 +149,7 @@ export class RankingComponent implements OnInit {
       rankings: this.userRankings
     }
     console.log('rankingUpdate: ' + JSON.stringify(rankingUpdate));
+    console.log(typeof(rankingUpdate));
     // THEN invoke apicall to put rankings into the DB.
     this.apicall.addUserRankings(rankingUpdate).subscribe();
   }

--- a/src/app/ranking/ranking.component.ts
+++ b/src/app/ranking/ranking.component.ts
@@ -74,8 +74,8 @@ export class RankingComponent implements OnInit {
   loadMovies() {
     if (environment.production === false) {
       this.movie = <PopMovieItem[]><unknown>popMovieSamples
-      this.userRankings = <PopMovieItem[]><unknown>popMovieSamples;
-      console.log("fake array: " + JSON.stringify(this.movie));
+      this.userRankings = <UserRankings[]><unknown>popMovieSamples;
+      console.log("fake array: " + JSON.stringify(this.userRankings));
       return this.movie;
     } else {
     return this.apicall.getMovies("Star Wars").subscribe((data) => {
@@ -103,7 +103,7 @@ export class RankingComponent implements OnInit {
         this.movieRankings.set(this.movie[i].title, newRanking);
         points--;
       } else {
-        this.movieRankings.set(this.movie[i].title, points);
+        this.movieRankings.set(this.userRankings[i].title, points);
 
         // Adds points attribute with the value determined to the movie in userRankings array
         let movieIndex = this.userRankings.findIndex(x => x.title === this.movie[i].title);
@@ -141,6 +141,7 @@ export class RankingComponent implements OnInit {
       //this.userRankings.find(x => x.title === entry[0])
     }
     console.log(this.userRankings);
+    console.log(typeof(this.userRankings));
 
     // Still need to figure out how to target the movieEvent.id
     let rankingUpdate: RankUpdate = {
@@ -150,6 +151,7 @@ export class RankingComponent implements OnInit {
     }
     console.log('rankingUpdate: ' + JSON.stringify(rankingUpdate));
     console.log(typeof(rankingUpdate));
+    console.log('rankings: ' + JSON.stringify(rankingUpdate.rankings));
     // THEN invoke apicall to put rankings into the DB.
     this.apicall.addUserRankings(rankingUpdate).subscribe();
   }

--- a/src/app/ranking/ranking.component.ts
+++ b/src/app/ranking/ranking.component.ts
@@ -49,7 +49,7 @@ export class RankingComponent implements OnInit {
 
   movieEvent: MovieEvent[] = []; // the event info the ranking is for
   movie: PopMovieItem[] = []; 
-  id = 'testid';   // the movies to be ranked (from event) -- does this need to be separate?
+  id = '3u0lmogh79d';   // the movies to be ranked (from event) -- does this need to be separate?
   value = '';
   eventTitle = '';
   eventDate = '';


### PR DESCRIPTION
For Issue #81 - Update Ranking Component to add User Rankings to the Event Table

This feature enhances the Rankings component, by allowing visitors/guests to enter a userID, use the click/drag feature to rank movies from highest to lowest, and then submit these rankings to the Event table, where the lambda function will "eventRankings" (consisting of the userID and their userRankings selections to the indicated eventID. 
If the eventID indicated does not have any eventRankings, it will be created for the eventID. If it alread has eventRankings entries, a new set of userID-userRankings will be appended to the eventRankings attribute.

This PR also has some optimizing of the ranking.component.html, allowing the userID to be displayed to the user as they are typing it, with no need to press the Enter Key, as well as displaying the user's current top choice, but not a total top choice for all userRankings.

Tested on Win10 laptop, Chrome v92.

Sample Ranking Page Image:
![image](https://user-images.githubusercontent.com/49133101/128590271-afaf85d1-9ba4-4f22-84b2-be1dcfc89a4e.png)

To Test the feature:

From the Home page (localhost:4200/)
- [x] Select one of the current red "DEMO" created event buttons.
- [x] On the ranking page for this event, enter a UserID in the form field. the "User ID: No User ID entered" line should change as you type, as well as "Your current top choice:" should change to be "[UserID]'s Current Top Choice:".
![image](https://user-images.githubusercontent.com/49133101/128590426-0446808f-2054-4774-9ae6-eee80216b8dc.png)

- [x] Adjust movie positions, if desired.
- [x] Click the Submit button.
- - [x] In the console, you will currently see the output of the eventRanking update, showing the eventID, userID, and rankings:
![image](https://user-images.githubusercontent.com/49133101/128590488-0cbf0c88-7b7e-4bee-9411-067e816efc6e.png)

- - [x] additionally, a successful apicall will return the information added to the database to the console:
![image](https://user-images.githubusercontent.com/49133101/128590564-40494201-ba65-4607-ae7a-af2ae23c4009.png)

- [ ] This can also be verified by logging into the DynamoDB console, search for the Event table items for the event id, and selecting the id link to see the json-formatted entry:
![image](https://user-images.githubusercontent.com/49133101/128590678-76e9c85d-ad8b-4147-b3ed-ef3013a79a1d.png)


