### PR TITLE
update datepicker settings to block past dates during event creation

### DIFF
--- a/src/app/event/event.component.html
+++ b/src/app/event/event.component.html
@@ -18,8 +18,8 @@
   <mat-label>Choose a Date</mat-label>
   <input
     matInput
+    [min]="minDate"
     [matDatepicker]="picker"
-    [value]="date.value"
     (dateInput)="setDate($event)"
   />
   <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
@@ -67,13 +67,12 @@
   </table>
 </div>-->
 
-  <!-- GRID TO DISPLAY MOVIES -->
-  <div class="content">
-    <div fxLayout="row wrap" fxLayoutGap="16px grid">
-      <div class="content" *ngFor="let movie of eventMovies">
-        <app-movie-card [movie]="movie"> </app-movie-card>
-        <div>{{movie.title}}</div>
-      </div>
+<!-- GRID TO DISPLAY MOVIES -->
+<div class="content">
+  <div fxLayout="row wrap" fxLayoutGap="16px grid">
+    <div class="content" *ngFor="let movie of eventMovies">
+      <app-movie-card [movie]="movie"> </app-movie-card>
+      <div>{{ movie.title }}</div>
     </div>
   </div>
-
+</div>

--- a/src/app/event/event.component.ts
+++ b/src/app/event/event.component.ts
@@ -52,11 +52,14 @@ export class EventComponent implements OnInit {
   public confirmed = false;
   date = new FormControl(new Date());
   gridColumns = 3;
+  minDate = new Date();
 
   constructor(public apicall: ApicallService, private eventService: EventService, private httpClient: HttpClient) {}
 
   ngOnInit(): void {
     this.loadPopMovies();
+    // set minDate for datepicker to be 'tomorrow'--no past dates or picking today.
+    this.minDate.setDate(this.minDate.getDate() +1);
   }
 
   // CALL SCAN API GATEWAY HERE? --> https://ri86qpqtti.execute-api.us-west-2.amazonaws.com/popMovies
@@ -70,6 +73,8 @@ export class EventComponent implements OnInit {
   }
 
   setDate(event: MatDatepickerInputEvent<Date>) {
+    
+    
     console.log(event.value);
     this.eventDate = `${event.value}`.substring(0, 15);
     console.log("New EventDate: " + this.eventDate);


### PR DESCRIPTION
Bug Fix-- Issue #88 - disallow past dates during Event Creation

During the initial event creation setup, any date could be selected from the datepicker, and todays date was displayed in the form field on page load.
This fix removes any dates before tomorrow from being selected, and removes today's date from the form field, to avoid confusion.

Tested on: Win10 laptop, Chrome v92.

To verify bug fix:

- [x] from the home page, select "Create Event" button.
- [x] On the Event Creation page, note the text in the Date form field now says, "Choose a Date".
- [ ] click on icon to the right of the form field to reveal the calendar.
- [ ] note that today's date and all past dates are grayed out, and are not selectable, while all future dates are black and may be selected.
- [ ] selecting any future date will fill the form field with the selected date, providing visual confirmation for the host creator.

![image](https://user-images.githubusercontent.com/49133101/129432010-17e7081a-44dc-4854-b628-b2c39c812b83.png)
