### PR TITLE
Kj 86 get events bux fix

### DIFF
--- a/src/app/apicall.service.ts
+++ b/src/app/apicall.service.ts
@@ -88,8 +88,8 @@ export class ApicallService {
     return this.http.get<MovieEvents>('https://ri86qpqtti.execute-api.us-west-2.amazonaws.com/movieevents-scan').
       pipe(
         map((data) => {
-          console.log(data);
-          console.log("getMovieEvents() data.Items: " + data.Items);
+          //console.log(data);
+          //console.log("getMovieEvents() data.Items: " + data.Items);
           return data.Items ?? [];
         })
       )

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -3,11 +3,12 @@ import { RouterModule, Routes } from '@angular/router';
 import { EventComponent } from './event/event.component';
 import { RankingComponent } from "./ranking/ranking.component";
 import { HomeComponent } from "./home/home.component";
+import { MovieEventResolve } from './ranking.resolve';
 
 const routes: Routes = [
     { path: 'home', pathMatch: 'full', component: HomeComponent },
     { path: '', redirectTo: '/home', pathMatch: 'full' },
-    { path: 'ranking/:eventID', component: RankingComponent },
+    { path: 'ranking/:eventID', component: RankingComponent, resolve: {movieEvent: MovieEventResolve} },
     { path: 'event', component: EventComponent }
     /* add path for movie selection */
 ];

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -14,6 +14,7 @@ import { HomeComponent} from "./home/home.component";
 import { TopNavComponent } from "./topNav/topNav.component";
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { MovieCardComponent} from "./movieCard/movieCard.component";
+import { ApicallService } from './apicall.service';
 
 @NgModule({
   declarations: [
@@ -36,6 +37,7 @@ import { MovieCardComponent} from "./movieCard/movieCard.component";
     FlexLayoutModule
   ],
   providers: [
+    ApicallService,
     { provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: { appearance: 'fill' } },
   ],
   bootstrap: [AppComponent]

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -3,6 +3,7 @@ import { ApicallService } from '../apicall.service';
 import { HttpClient } from '@angular/common/http';
 import { MovieEvent } from '../event/event.component';
 import { RankingService } from '../ranking.service';
+import { environment } from 'src/environments/environment';
 
 @Component({
   selector: 'app-home',
@@ -12,13 +13,11 @@ import { RankingService } from '../ranking.service';
 
 export class HomeComponent implements OnInit {
   movieEvents: MovieEvent[] = [];
-  demoID = "DEMO";
   constructor(public apicall: ApicallService, private rankingService: RankingService, private httpClient: HttpClient) { }
 
   ngOnInit(): void {
-    this.rankingService.loadMovieEventsByHostID(this.demoID);
+    this.rankingService.loadMovieEventsByHostID(environment.demoUserID);
     this.movieEvents = this.rankingService.getMovieEvents();
-    // maybe take the assignment of the movieEvents out of ngOnInit, it is adding movies each time to the movieEvents variable
   }
 
 }

--- a/src/app/ranking.resolve.ts
+++ b/src/app/ranking.resolve.ts
@@ -1,0 +1,20 @@
+import { Injectable } from "@angular/core";  
+import { Resolve, ActivatedRouteSnapshot } from "@angular/router";  
+import { Observable } from "rxjs";  
+import { environment } from "src/environments/environment";
+import { ApicallService } from "./apicall.service";  
+import { MovieEvent } from './event/event.component';
+import { RankingService } from "./ranking.service";
+
+  
+@Injectable({  
+  providedIn: "any"
+})
+export class MovieEventResolve implements Resolve<MovieEvent[]> {  
+  constructor(private apicall: ApicallService, private rankingService: RankingService) {}  
+  
+  resolve(route: ActivatedRouteSnapshot): Observable<MovieEvent[]> {  
+    console.log("the resolve has completed");
+    return this.apicall.getMovieEvents();
+  }  
+}

--- a/src/app/ranking.service.ts
+++ b/src/app/ranking.service.ts
@@ -15,7 +15,7 @@ export class RankingService {
 
   loadMovieEventsByHostID(demoID: String): MovieEvent[] {
     this.apicall.getMovieEvents().subscribe((data) => {
-      //console.log(data);
+      console.log(data);
       for (let index in data) {
         // make sure the hostID equals the demoID, and that the id does not already exist in the movieEvents array
         if ((data[index].hostID == demoID) && (data[index].id != (this.movieEvents.find(event => event.id == data[index].id))?.id)) {
@@ -24,6 +24,20 @@ export class RankingService {
       }
     }); 
     return this.movieEvents;
+  }
+
+  findMovieEventByEventID(hostID: String, eventID: String) {
+    console.log(this.movieEvents);
+    let temp: MovieEvent | undefined;
+    for (let index in this.movieEvents) {
+      // make sure the hostID and eventIDs match
+     if ((this.movieEvents[index].hostID == hostID && this.movieEvents[index].id == eventID )) {
+         temp = this.movieEvents[index];
+         console.log("found it!");
+      }
+    }
+    console.log(temp);
+    return temp;
   }
 
   getMovieEvents(){

--- a/src/app/ranking.service.ts
+++ b/src/app/ranking.service.ts
@@ -3,6 +3,8 @@ import { HttpClient } from '@angular/common/http';
 import { Movies, MovieItem, PopMovies, PopMovieItem } from './movies';
 import { MovieEvent } from './event/event.component';
 import { ApicallService } from './apicall.service';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment.prod';
 
 @Injectable({
   providedIn: 'root'
@@ -11,27 +13,21 @@ export class RankingService {
   movieEvents: MovieEvent[] = [];
   constructor(public apicall: ApicallService, private http: HttpClient) {}
 
-  loadMovieEventsByHostID(demoID: String) {
+  loadMovieEventsByHostID(demoID: String): MovieEvent[] {
     this.apicall.getMovieEvents().subscribe((data) => {
-      console.log(data);
+      //console.log(data);
       for (let index in data) {
         // make sure the hostID equals the demoID, and that the id does not already exist in the movieEvents array
-       if ((data[index].hostID == demoID) && (data[index].id != (this.movieEvents.find(event => event.id == data[index].id))?.id)) {
+        if ((data[index].hostID == demoID) && (data[index].id != (this.movieEvents.find(event => event.id == data[index].id))?.id)) {
           this.movieEvents.push(data[index]);
         }
       }
-      console.log("Ranking service MovieEvents: " + this.movieEvents);
-      })
+    }); 
+    return this.movieEvents;
   }
 
   getMovieEvents(){
     return this.movieEvents;
-  }
-
-  getMovieEventByEventID(demoID: String, eventID: String){
-    this.loadMovieEventsByHostID(demoID);
-    console.log("getMoviesByEventID: "+this.movieEvents);
-    return this.movieEvents.find(event => event.id == eventID);
   }
 }
 

--- a/src/app/ranking.service.ts
+++ b/src/app/ranking.service.ts
@@ -20,7 +20,7 @@ export class RankingService {
           this.movieEvents.push(data[index]);
         }
       }
-      console.log(this.movieEvents);
+      console.log("Ranking service MovieEvents: " + this.movieEvents);
       })
   }
 
@@ -28,7 +28,9 @@ export class RankingService {
     return this.movieEvents;
   }
 
-  getMovieEventByEventID(eventID: String){
+  getMovieEventByEventID(demoID: String, eventID: String){
+    this.loadMovieEventsByHostID(demoID);
+    console.log("getMoviesByEventID: "+this.movieEvents);
     return this.movieEvents.find(event => event.id == eventID);
   }
 }

--- a/src/app/ranking/ranking.component.html
+++ b/src/app/ranking/ranking.component.html
@@ -46,7 +46,7 @@
 </div>
 
 <!-- Adjust this so they are dragging movie posters? -->
-<div *ngIf="movieItemArray" cdkDropList class="example-list" (cdkDropListDropped)="drop($event)">
+<div *ngIf="movieEvents" cdkDropList class="example-list" (cdkDropListDropped)="drop($event)">
   <div class="example-box" *ngFor="let movie of movieItemArray" cdkDrag>
     {{ movie.title }}
     <img *cdkDragPreview [src]="movie.image" [alt]="movie.title" />

--- a/src/app/ranking/ranking.component.html
+++ b/src/app/ranking/ranking.component.html
@@ -33,7 +33,7 @@
 </p>
 
 <div>
-  <h2>
+  <h2 >
     {{ userID === "" ? "Your" : userID + "'s" }} Current Top Choice:
     {{
       movieItemArray === undefined
@@ -46,7 +46,7 @@
 </div>
 
 <!-- Adjust this so they are dragging movie posters? -->
-<div cdkDropList class="example-list" (cdkDropListDropped)="drop($event)">
+<div *ngIf="movieItemArray" cdkDropList class="example-list" (cdkDropListDropped)="drop($event)">
   <div class="example-box" *ngFor="let movie of movieItemArray" cdkDrag>
     {{ movie.title }}
     <img *cdkDragPreview [src]="movie.image" [alt]="movie.title" />

--- a/src/app/ranking/ranking.component.ts
+++ b/src/app/ranking/ranking.component.ts
@@ -42,10 +42,11 @@ export class RankingComponent implements OnInit {
   movieItemArray: (PopMovieItem)[] | undefined;
   movieRankings = new Map();
   errorMsg = '';
-
+  eventIDFromRoute = '';
   highestRank = 'no highest rank';
   movieEvent: MovieEvent | undefined;
   url = 'http://localhost:4200/ranking/';
+  movieEvents: MovieEvent[] = [];
 
   constructor(public apicall: ApicallService, private rankingService: RankingService, private router: Router, private httpClient: HttpClient, private route: ActivatedRoute,) {
   }
@@ -53,11 +54,11 @@ export class RankingComponent implements OnInit {
   ngOnInit() {
     // First get the event id from the current route.
     const routeParams = this.route.snapshot.paramMap;
-    const eventIDFromRoute = String(routeParams.get('eventID'));
-    console.log("eventIDFromRoute: " + eventIDFromRoute);
+    this.eventIDFromRoute = String(routeParams.get('eventID'));
+    console.log("eventIDFromRoute: " + this.eventIDFromRoute);
 
-    // Find the event that correspond with the id provided in route.
-    this.movieEvent = JSON.parse(JSON.stringify(this.rankingService.getMovieEventByEventID(eventIDFromRoute)));
+    // Find the event that corresponds with the id provided in route.
+    this.movieEvent = this.rankingService.getMovieEventByEventID(environment.demoUserID, this.eventIDFromRoute);
     //this.movieEvent = this.rankingService.getMovieEventByEventID(eventIDFromRoute);
     console.log("movieEvent: " + JSON.stringify(this.movieEvent));
     this.loadMoviesFromEvent();

--- a/src/app/ranking/ranking.component.ts
+++ b/src/app/ranking/ranking.component.ts
@@ -62,7 +62,7 @@ export class RankingComponent implements OnInit {
     // First get the event id from the current route.
     const routeParams = this.route.snapshot.paramMap;
     this.eventIDFromRoute = String(routeParams.get('eventID'));
-    console.log("eventIDFromRoute: " + this.eventIDFromRoute);
+    //console.log("eventIDFromRoute: " + this.eventIDFromRoute);
 
     // Find the event that corresponds with the id provided in route
     this.movieEvents = this.route.snapshot.data.movieEvent;

--- a/src/app/ranking/ranking.component.ts
+++ b/src/app/ranking/ranking.component.ts
@@ -38,6 +38,7 @@ export class RankingComponent implements OnInit {
   eventDate = '';
   value = '';
   userID = '';
+  hostID = environment.demoUserID;
   title = 'Movie ranking';
   movieItemArray: (PopMovieItem)[] | undefined;
   movieRankings = new Map();
@@ -48,20 +49,38 @@ export class RankingComponent implements OnInit {
   url = 'http://localhost:4200/ranking/';
   movieEvents: MovieEvent[] = [];
 
-  constructor(public apicall: ApicallService, private rankingService: RankingService, private router: Router, private httpClient: HttpClient, private route: ActivatedRoute,) {
+  constructor(
+    public apicall: ApicallService, 
+    private rankingService: RankingService, 
+    private router: Router, 
+    private httpClient: HttpClient, 
+    private route: ActivatedRoute) {
   }
 
-  ngOnInit() {
+  async ngOnInit() {
+    this.movieEvents = this.route.snapshot.data.movieEvents;
     // First get the event id from the current route.
     const routeParams = this.route.snapshot.paramMap;
     this.eventIDFromRoute = String(routeParams.get('eventID'));
     console.log("eventIDFromRoute: " + this.eventIDFromRoute);
 
-    // Find the event that corresponds with the id provided in route.
-    this.movieEvent = this.rankingService.getMovieEventByEventID(environment.demoUserID, this.eventIDFromRoute);
-    //this.movieEvent = this.rankingService.getMovieEventByEventID(eventIDFromRoute);
-    console.log("movieEvent: " + JSON.stringify(this.movieEvent));
+    // Find the event that corresponds with the id provided in route
+    this.movieEvents = this.route.snapshot.data.movieEvent;
+    console.log("movieEvents?", this.movieEvents);
+    this.findMovieEventByEventID();
+    
     this.loadMoviesFromEvent();
+  }
+
+  findMovieEventByEventID() {
+    //console.log(this.movieEvents);
+    for (let index in this.movieEvents) {
+      // make sure the hostID and eventIDs match
+     if ((this.movieEvents[index].hostID == this.hostID && this.movieEvents[index].id == this.eventIDFromRoute )) {
+        this.movieEvent = this.movieEvents[index];
+        console.log("adding movieEvent: ", this.movieEvent);
+      }
+    }
   }
 
   loadMoviesFromEvent() {


### PR DESCRIPTION
# Description
As a USER, I want to be able to copy and paste the URL into the browser and be able to see the Ranking page populated with the details for that event. I also want to be able to click on the URL inside the invite email and be able to see the Ranking page populated with details for that event. 
Closes #86 

# Tested
* On MacOS with Chrome browser

# Testing 
- [ ] Click on an Event button from the current Home page to navigate to a Ranking page
- [ ] Copy and paste the URL into another tab on your browser
- [ ] View the Ranking page with details for that event
- [ ] Send an invite email from the Ranking page
- [ ] View invite email after it is received
- [ ] Click on invite email URL
- [ ] View the Ranking page with details from that event