### PR TITLE
Mg 93 ranking cutoff time

### DIFF
--- a/src/app/event/event.component.ts
+++ b/src/app/event/event.component.ts
@@ -74,8 +74,6 @@ export class EventComponent implements OnInit {
   }
 
   setDate(event: MatDatepickerInputEvent<Date>) {
-    
-    
     console.log(event.value);
     this.eventDate = `${event.value}`.substring(0, 15);
     console.log("New EventDate: " + this.eventDate);

--- a/src/app/ranking/ranking.component.ts
+++ b/src/app/ranking/ranking.component.ts
@@ -117,7 +117,7 @@ export class RankingComponent implements OnInit {
   }
 
   getDifferenceInDays(date1: Date, date2: Date) {
-    const diffInMs = Math.abs(date2.getTime() - date1.getTime());
+    const diffInMs = Math.abs(date1.getTime() - date2.getTime());
     return diffInMs / (1000 * 60 * 60 * 24);
   }
 

--- a/src/app/ranking/ranking.component.ts
+++ b/src/app/ranking/ranking.component.ts
@@ -76,12 +76,29 @@ export class RankingComponent implements OnInit {
     //console.log(this.movieEvents);
     for (let index in this.movieEvents) {
       // make sure the hostID and eventIDs match
-     if ((this.movieEvents[index].hostID == this.hostID && this.movieEvents[index].id == this.eventIDFromRoute )) {
+      if ((this.movieEvents[index].hostID == this.hostID && this.movieEvents[index].id == this.eventIDFromRoute )) {
         this.movieEvent = this.movieEvents[index];
         console.log("adding movieEvent: ", this.movieEvent);
+        const testdate = new Date( Date.parse(this.movieEvent.eventDate) )
+        const today = new Date();
+        console.log("TESTDATE?: " + testdate);
+        if (this.getDifferenceInDays(today,testdate) < 1) {
+          this.router.navigateByUrl(`finalranking/${this.eventIDFromRoute}`);
+        }
+        console.log("today get time: " + today.getTime());
+        console.log("testdate get time: " + testdate.getTime());
+        console.log("getDifferenceInDays: " + this.getDifferenceInDays(today, testdate));
       }
     }
   }
+
+  
+    
+    
+      //this.eventDate.getDate() + 1)
+      //console.log(JSON.parse(this.eventDate));
+      
+  
 
   loadMoviesFromEvent() {
     // if movieEvent is not undefined or null, assign movies to movieItemArray
@@ -95,7 +112,15 @@ export class RankingComponent implements OnInit {
         this.url = this.url + this.id;
       }
     }
+    
+
   }
+
+  getDifferenceInDays(date1: Date, date2: Date) {
+    const diffInMs = Math.abs(date2.getTime() - date1.getTime());
+    return diffInMs / (1000 * 60 * 60 * 24);
+  }
+
 
   drop(event: CdkDragDrop<{ title: string, image: string }[]>) {
     if (this.movieItemArray) {


### PR DESCRIPTION
For Issue #93 - Adjust ranking cutoff time to one day before eventDate.

As a User, I want to have a cut off time for adding more UserRankings, so that rankings aren't being added right up to the start of the event, and have anyone who follows the ranking link be automatically routed to the final-rankings page instead. I want to have the cut off be the day before the event, to give time to make a final announcement, or locate the selected movie, etc.

Tested on: Win10 laptop, Chrome v92.

To verify: 
- **PRE:  TEST THIS ON MON, 8/16.**
- your environment.ts file should have "DemoUserId" set to "DEMO".

- [ ] On the Home Page, select the Orange ranking button for "Ranking Cutoff Test" **(this event has a eventDate of 8/17)**.
- [ ] You should be quickly re-routed from the rankings page as the movieEvent info is loading to the final-rankings page for the event instead.
- [ ] this also works if you go directly to the link (http://localhost:4200/ranking/my6raivrzu).

_**NOTE:** The re-routing won't occur if you are > 1 day from the eventDate._