### PR TITLE
Mg 121 authguard

### DIFF
--- a/src/app/apicall.service.ts
+++ b/src/app/apicall.service.ts
@@ -89,7 +89,7 @@ export class ApicallService {
       pipe(
         map((data) => {
           //console.log(data);
-          //console.log("getMovieEvents() data.Items: " + data.Items);
+          console.log("ApiService- getMovieEvents() completed");
           return data.Items ?? [];
         })
       )

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -10,9 +10,9 @@ import { IntroComponent } from './intro/intro.component';
 import { AuthGuard } from './auth.guard';
 
 const routes: Routes = [
-    { path: 'home', pathMatch: 'full', component: HomeComponent, canActivate: [AuthGuard] }, // TODO: add authGuard--> canActivate: [RedirectGuard]
+    { path: 'home', pathMatch: 'full', component: HomeComponent, canActivate: [AuthGuard] },
     { path: '', redirectTo: '/intro', pathMatch: 'full' },
-    { path: '', pathMatch: 'full', component: HomeComponent },
+    //{ path: '', pathMatch: 'full', component: HomeComponent },
     { path: 'ranking/:eventID', component: RankingComponent, resolve: {movieEvent: MovieEventResolve} },
     { path: 'event', pathMatch: 'full', component: EventComponent, canActivate: [AuthGuard] },
     { path: 'finalranking/:eventID', component: FinalRankingComponent, resolve: {finalRanking: FinalRankingResolve} },

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -10,11 +10,11 @@ import { IntroComponent } from './intro/intro.component';
 import { AuthGuard } from './auth.guard';
 
 const routes: Routes = [
-    { path: 'home', pathMatch: 'full', component: HomeComponent /*, canActivate: [AuthGuard]*/ }, // TODO: add authGuard--> canActivate: [RedirectGuard]
+    { path: 'home', pathMatch: 'full', component: HomeComponent, canActivate: [AuthGuard] }, // TODO: add authGuard--> canActivate: [RedirectGuard]
     { path: '', redirectTo: '/intro', pathMatch: 'full' },
     { path: '', pathMatch: 'full', component: HomeComponent },
     { path: 'ranking/:eventID', component: RankingComponent, resolve: {movieEvent: MovieEventResolve} },
-    { path: 'event', pathMatch: 'full', component: EventComponent /*, canActivate: [AuthGuard] */ },
+    { path: 'event', pathMatch: 'full', component: EventComponent, canActivate: [AuthGuard] },
     { path: 'finalranking/:eventID', component: FinalRankingComponent, resolve: {finalRanking: FinalRankingResolve} },
     { path: 'intro', pathMatch: 'full', component: IntroComponent }
     /* add path for movie selection */

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -12,7 +12,7 @@ import { AuthGuard } from './auth.guard';
 const routes: Routes = [
     { path: 'home', pathMatch: 'full', component: HomeComponent, canActivate: [AuthGuard] },
     { path: '', redirectTo: '/intro', pathMatch: 'full' },
-    //{ path: '', pathMatch: 'full', component: HomeComponent },
+    { path: '', pathMatch: 'full', component: HomeComponent },
     { path: 'ranking/:eventID', component: RankingComponent, resolve: {movieEvent: MovieEventResolve} },
     { path: 'event', pathMatch: 'full', component: EventComponent, canActivate: [AuthGuard] },
     { path: 'finalranking/:eventID', component: FinalRankingComponent, resolve: {finalRanking: FinalRankingResolve} },

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -7,15 +7,16 @@ import { MovieEventResolve } from './ranking.resolve';
 import { FinalRankingResolve } from './finalRanking.resolve';
 import { FinalRankingComponent } from './finalRanking/final-ranking.component';
 import { IntroComponent } from './intro/intro.component';
+import { AuthGuard } from './auth.guard';
 
 const routes: Routes = [
-    { path: 'home', pathMatch: 'full', component: HomeComponent }, // TODO: add authGuard--> canActivate: [RedirectGuard]
+    { path: 'home', pathMatch: 'full', component: HomeComponent /*, canActivate: [AuthGuard]*/ }, // TODO: add authGuard--> canActivate: [RedirectGuard]
     { path: '', redirectTo: '/intro', pathMatch: 'full' },
     { path: '', pathMatch: 'full', component: HomeComponent },
     { path: 'ranking/:eventID', component: RankingComponent, resolve: {movieEvent: MovieEventResolve} },
-    { path: 'event', component: EventComponent },
+    { path: 'event', pathMatch: 'full', component: EventComponent /*, canActivate: [AuthGuard] */ },
     { path: 'finalranking/:eventID', component: FinalRankingComponent, resolve: {finalRanking: FinalRankingResolve} },
-    { path: 'intro', component: IntroComponent }
+    { path: 'intro', pathMatch: 'full', component: IntroComponent }
     /* add path for movie selection */
 ];
 

--- a/src/app/auth-interceptor.ts
+++ b/src/app/auth-interceptor.ts
@@ -25,7 +25,7 @@ export class HeaderInterceptor implements HttpInterceptor {
   intercept(httpRequest: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
 
             const IdAuthToken = String(sessionStorage.getItem('id_token'));
-      
+            console.log('Interceptor: setting auth header');
         return next.handle(httpRequest.clone({ setHeaders: { 'Authorization': IdAuthToken } }));
   }
 }

--- a/src/app/auth.guard.spec.ts
+++ b/src/app/auth.guard.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AuthGuard } from './auth.guard';
+
+describe('AuthGuard', () => {
+  let guard: AuthGuard;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    guard = TestBed.inject(AuthGuard);
+  });
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+});

--- a/src/app/auth.guard.ts
+++ b/src/app/auth.guard.ts
@@ -1,25 +1,36 @@
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivate, RouterStateSnapshot, Router, UrlTree } from '@angular/router';
 import { Observable } from 'rxjs';
+import { AuthService } from './auth.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class AuthGuard implements CanActivate {
-  redirectURL: string | null = null;
+  
 
-  constructor(private router: Router) {}
+  constructor(private authService: AuthService, private router: Router) {}
 
   canActivate(
-    route: ActivatedRouteSnapshot,
-    state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    next: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot): true|UrlTree {
+      const url: string = state.url;
+      console.log('state url: ' + url);
       console.log('AuthGuard#canActivate called');
-      //if (sessionStorage.getItem('hostId') !== null) {
-        return true;
-      //} else {
-        //return this.router.parseUrl('/intro');
-      //}
-      
+      if (url.includes('id_token')) {
+        this.authService.login();
+        return this.checkLogin(url);
+      }
+      return this.checkLogin(url);   
+  }
+
+  checkLogin(url: string): true|UrlTree {
+    console.log('checkLogin: isLoggedin=' + this.authService.isLoggedIn);
+    if (this.authService.isLoggedIn) {
+      return true;
+    }
+    this.authService.redirectURL = url;
+    return this.router.parseUrl('/intro');
   }
   
 }

--- a/src/app/auth.guard.ts
+++ b/src/app/auth.guard.ts
@@ -27,6 +27,10 @@ export class AuthGuard implements CanActivate {
   }
 
   checkLogin(url: string): true|UrlTree {
+    // for page refresh when logged in - AuthService wants to reset variables on a page refresh
+    if (sessionStorage.getItem("hostID") !== null) {
+      this.authService.isLoggedIn = true;
+    }
     console.log('checkLogin: isLoggedin=' + this.authService.isLoggedIn);
     if (this.authService.isLoggedIn) {
       return true;

--- a/src/app/auth.guard.ts
+++ b/src/app/auth.guard.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivate, RouterStateSnapshot, Router, UrlTree } from '@angular/router';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AuthGuard implements CanActivate {
+  redirectURL: string | null = null;
+
+  constructor(private router: Router) {}
+
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+      console.log('AuthGuard#canActivate called');
+      //if (sessionStorage.getItem('hostId') !== null) {
+        return true;
+      //} else {
+        //return this.router.parseUrl('/intro');
+      //}
+      
+  }
+  
+}

--- a/src/app/auth.guard.ts
+++ b/src/app/auth.guard.ts
@@ -13,10 +13,12 @@ export class AuthGuard implements CanActivate {
 
   canActivate(
     next: ActivatedRouteSnapshot,
+    // capture url
     state: RouterStateSnapshot): true|UrlTree {
       const url: string = state.url;
       console.log('state url: ' + url);
       console.log('AuthGuard#canActivate called');
+      // if url has hosted UI login info, then run AuthService login function
       if (url.includes('id_token')) {
         this.authService.login();
         return this.checkLogin(url);

--- a/src/app/auth.service.spec.ts
+++ b/src/app/auth.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AuthService } from './auth.service';
+
+describe('AuthService', () => {
+  let service: AuthService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AuthService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/auth.service.ts
+++ b/src/app/auth.service.ts
@@ -1,0 +1,65 @@
+import { Injectable } from '@angular/core';
+import { Observable, of } from 'rxjs';
+import { tap, delay } from 'rxjs/operators';
+import jwtDecode, { JwtPayload }  from "jwt-decode";
+
+export interface JwtPayloadCognito extends JwtPayload {
+  preferred_username: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AuthService {
+  isLoggedIn = false;
+  redirectURL: string | null = null;
+  idToken = '';
+  accessToken = '';
+
+  login(): Observable<boolean>{
+
+    if (sessionStorage.getItem("hostID") !== null) {
+      this.isLoggedIn = true;
+    }
+    //if (sessionStorage.getItem("LoggedStatus") === null) {
+      if (sessionStorage.getItem("hostID") === null) {
+        var url = new URL(window.location.href.replace('#', '?'));
+        console.log("URL: " + url);
+        console.log("href: "+ window.location.href);
+        
+        // session storage value of loggedin t/f, if session storage has them logged in already, it skips the Params setup?
+  
+        const urlSearchParams = url.searchParams;
+        console.log("urlSP: "+ urlSearchParams);
+        this.idToken = String(url.searchParams.get("id_token"));
+        this.accessToken = String(url.searchParams.get("access_token"));
+        
+        console.log("idToken: " + this.idToken);
+        console.log("accessToken: " + this.accessToken);
+  
+        const decoded = jwtDecode<JwtPayloadCognito>(this.idToken);
+        // do we need to decode the accessToken, as well?  Not sure when that will be needed, possibly for Creating Events
+        console.log(decoded);
+  
+        sessionStorage.setItem('hostID', decoded.preferred_username);
+        sessionStorage.setItem('id_token', this.idToken);
+        sessionStorage.setItem('access_token', this.accessToken);
+        //sessionStorage.setItem('LoggedStatus', 'true');
+        this.isLoggedIn = true;
+  
+        console.log("session storage-host: "+ sessionStorage.getItem('hostID'));
+        console.log("session storage-idToken: " + sessionStorage.getItem('id_token')); 
+        console.log("session storage-accessToken: " + sessionStorage.getItem('access_token'));
+  
+        
+      } 
+    return of(true).pipe(
+      delay(1000),
+      tap(() => this.isLoggedIn = true)
+    );
+  }
+
+  logout(): void {
+    this.isLoggedIn = false;
+  }
+}

--- a/src/app/auth.service.ts
+++ b/src/app/auth.service.ts
@@ -18,41 +18,39 @@ export class AuthService {
 
   login(): Observable<boolean>{
 
+    // for page refresh when logged in - AuthService wants to reset variables on a page refresh
     if (sessionStorage.getItem("hostID") !== null) {
       this.isLoggedIn = true;
     }
-    //if (sessionStorage.getItem("LoggedStatus") === null) {
-      if (sessionStorage.getItem("hostID") === null) {
-        var url = new URL(window.location.href.replace('#', '?'));
-        console.log("URL: " + url);
-        console.log("href: "+ window.location.href);
-        
-        // session storage value of loggedin t/f, if session storage has them logged in already, it skips the Params setup?
-  
-        const urlSearchParams = url.searchParams;
-        console.log("urlSP: "+ urlSearchParams);
-        this.idToken = String(url.searchParams.get("id_token"));
-        this.accessToken = String(url.searchParams.get("access_token"));
-        
-        console.log("idToken: " + this.idToken);
-        console.log("accessToken: " + this.accessToken);
-  
-        const decoded = jwtDecode<JwtPayloadCognito>(this.idToken);
-        // do we need to decode the accessToken, as well?  Not sure when that will be needed, possibly for Creating Events
-        console.log(decoded);
-  
-        sessionStorage.setItem('hostID', decoded.preferred_username);
-        sessionStorage.setItem('id_token', this.idToken);
-        sessionStorage.setItem('access_token', this.accessToken);
-        //sessionStorage.setItem('LoggedStatus', 'true');
-        this.isLoggedIn = true;
-  
-        console.log("session storage-host: "+ sessionStorage.getItem('hostID'));
-        console.log("session storage-idToken: " + sessionStorage.getItem('id_token')); 
-        console.log("session storage-accessToken: " + sessionStorage.getItem('access_token'));
-  
-        
-      } 
+    if (sessionStorage.getItem("hostID") === null) {
+      var url = new URL(window.location.href.replace('#', '?'));
+      console.log("URL: " + url);
+      console.log("href: "+ window.location.href);
+
+      const urlSearchParams = url.searchParams;
+      console.log("urlSP: "+ urlSearchParams);
+      this.idToken = String(url.searchParams.get("id_token"));
+      this.accessToken = String(url.searchParams.get("access_token"));
+      
+      console.log("idToken: " + this.idToken);
+      console.log("accessToken: " + this.accessToken);
+
+      const decoded = jwtDecode<JwtPayloadCognito>(this.idToken);
+      // do we need to decode the accessToken, as well?  Not sure when that will be needed, possibly for Creating Events
+      console.log(decoded);
+
+      sessionStorage.setItem('hostID', decoded.preferred_username);
+      sessionStorage.setItem('id_token', this.idToken);
+      sessionStorage.setItem('access_token', this.accessToken);
+
+      this.isLoggedIn = true;
+
+      console.log("session storage-host: "+ sessionStorage.getItem('hostID'));
+      console.log("session storage-idToken: " + sessionStorage.getItem('id_token')); 
+      console.log("session storage-accessToken: " + sessionStorage.getItem('access_token'));
+
+      
+    } 
     return of(true).pipe(
       delay(1000),
       tap(() => this.isLoggedIn = true)

--- a/src/app/auth.service.ts
+++ b/src/app/auth.service.ts
@@ -16,12 +16,15 @@ export class AuthService {
   idToken = '';
   accessToken = '';
 
-  login(): Observable<boolean>{
+ /*  ngOnInit() {
 
+  } */
+  login(): Observable<boolean>{
     // for page refresh when logged in - AuthService wants to reset variables on a page refresh
     if (sessionStorage.getItem("hostID") !== null) {
       this.isLoggedIn = true;
     }
+
     if (sessionStorage.getItem("hostID") === null) {
       var url = new URL(window.location.href.replace('#', '?'));
       console.log("URL: " + url);

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -1,1 +1,5 @@
-
+.logoutButton {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -31,7 +31,7 @@ export class HomeComponent implements OnInit {
   ngOnInit(): void {
     
     //if (sessionStorage.getItem("LoggedStatus") === null) {
-      if (sessionStorage.getItem("hostID") === null) {
+      /*if (sessionStorage.getItem("hostID") === null) {
       var url = new URL(window.location.href.replace('#', '?'));
       console.log("URL: " + url);
       console.log("href: "+ window.location.href);
@@ -60,7 +60,8 @@ export class HomeComponent implements OnInit {
       console.log("session storage-accessToken: " + sessionStorage.getItem('access_token'));
 
       
-    } 
+    } */
+    console.log("session storage-host: "+ sessionStorage.getItem('hostID'));
     this.rankingService.loadMovieEventsByHostID(String(sessionStorage.getItem('hostID')));
     this.movieEvents = this.rankingService.getMovieEvents();
    

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -21,46 +21,14 @@ export interface JwtPayloadCognito extends JwtPayload {
 
 export class HomeComponent implements OnInit {
   movieEvents: MovieEvent[] = [];
-  idToken = '';
-  accessToken = '';
+
   constructor(public apicall: ApicallService, private router: Router, private rankingService: RankingService, private httpClient: HttpClient, private route: ActivatedRoute) {
     };
 
     
 
   ngOnInit(): void {
-    
-    //if (sessionStorage.getItem("LoggedStatus") === null) {
-      /*if (sessionStorage.getItem("hostID") === null) {
-      var url = new URL(window.location.href.replace('#', '?'));
-      console.log("URL: " + url);
-      console.log("href: "+ window.location.href);
-      
-      // session storage value of loggedin t/f, if session storage has them logged in already, it skips the Params setup?
 
-      const urlSearchParams = url.searchParams;
-      console.log("urlSP: "+ urlSearchParams);
-      this.idToken = String(url.searchParams.get("id_token"));
-      this.accessToken = String(url.searchParams.get("access_token"));
-      
-      console.log("idToken: " + this.idToken);
-      console.log("accessToken: " + this.accessToken);
-
-      const decoded = jwtDecode<JwtPayloadCognito>(this.idToken);
-      // do we need to decode the accessToken, as well?  Not sure when that will be needed, possibly for Creating Events
-      console.log(decoded);
-
-      sessionStorage.setItem('hostID', decoded.preferred_username);
-      sessionStorage.setItem('id_token', this.idToken);
-      sessionStorage.setItem('access_token', this.accessToken);
-      sessionStorage.setItem('LoggedStatus', 'true');
-
-      console.log("session storage-host: "+ sessionStorage.getItem('hostID'));
-      console.log("session storage-idToken: " + sessionStorage.getItem('id_token')); 
-      console.log("session storage-accessToken: " + sessionStorage.getItem('access_token'));
-
-      
-    } */
     console.log("session storage-host: "+ sessionStorage.getItem('hostID'));
     this.rankingService.loadMovieEventsByHostID(String(sessionStorage.getItem('hostID')));
     this.movieEvents = this.rankingService.getMovieEvents();

--- a/src/app/intro/intro.component.ts
+++ b/src/app/intro/intro.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { AuthService } from '../auth.service';
 
 @Component({
   selector: 'app-intro',
@@ -7,10 +8,12 @@ import { Component, OnInit } from '@angular/core';
 })
 export class IntroComponent implements OnInit {
 
-  constructor() { }
+  constructor(private authService: AuthService) { }
 
   ngOnInit(): void {
     sessionStorage.clear();
+    // somehow, going to /intro is autmatically setting authService.isLoggedIn to false, and I'm not sure how.
+    //this.authService.logout();
   }
 
 }

--- a/src/app/intro/intro.component.ts
+++ b/src/app/intro/intro.component.ts
@@ -12,7 +12,8 @@ export class IntroComponent implements OnInit {
 
   ngOnInit(): void {
     sessionStorage.clear();
-    // somehow, going to /intro is autmatically setting authService.isLoggedIn to false, and I'm not sure how.
+
+    // somehow, going to /intro is already setting authService.isLoggedIn to false, and I'm not sure how.
     //this.authService.logout();
   }
 

--- a/src/app/ranking.service.ts
+++ b/src/app/ranking.service.ts
@@ -23,7 +23,7 @@ export class RankingService {
         }
       }
     });
-    console.log(this.movieEvents); 
+    console.log('RankingService-getMovieEventsByHostID completed: ' + this.movieEvents); 
     return this.movieEvents;
   }
 


### PR DESCRIPTION
Resolves Issue #121 (Add AuthGuard to redirect non-logged in uses who attempt to access /home or /event to the /intro page).

As an admin, I only want logged in users to have access to the Home and Event pages, and to have non-logged in users redirected to the Intro page. If a user attempts to access the Home or Event page directly, I want to ensure they are logged in before accessing user-specific pages.
This feature is addressed by introducing an auth.guard.ts and an auth.service.ts. Auth guard verifies if the page can be activated by checking that the user is logged in before displaying the page details. It makes use of the Auth Service which sets up determining if the user is logged in.
Previously, the home page had code that would parse the returned query string from the Cognito Hosted UI for the id_token, decode it and derive the "HostID" name, then save that information to sessionStorage to be used for determining what should be displayed on the Home Page.  That code has been moved into the AuthService's login function (since the home page cannot be accessed at all until that info is saved).

Tested on Win10 laptop, Chrome v92.

To Verify:
- [ ] start fresh localhost instance of the app.
- [ ] before logging in as a test user, attempt to go to "http://localhost:4200/home".
- - [x] You should be rerouted to the /intro page. Console logs will indicate AuthGaurd was called and isLoggedIn is false.
- [ ] attempt to go to http://localhost:4200/event".
- - [x] You should be rerouted to the /intro page. Console logs will indicate AuthGaurd was called and isLoggedIn is false.

- [ ] from the intro page, select login/signup button.
- [ ] Log in with established test user account.
- - [x] You should arrive at the home page, showing events for the logged in user. Console logs will indicate AuthGuard CanActivate was called, and will show AuthService's isLoggedIn variable set to true.
- [ ] Select the "build an event" button
- - [x] You should arrive on the event page, showing the hostID as the logged in user. Console logs will indicate AuthGuard CanActivate was called, and will show AuthService's isLoggedIn variable set to true.
- [ ] Select the topnav button to return to the Home page.
- - [x] You should return the Home Page as expected. Console logs should be the same as indicated above.
- [ ] Hit the refresh button on your browser window
- - [x] Page should reload the Home Page as expected, and not reroute to the intro page. Console logs should indicate AuthService's isLoggedIn variable set to true.
- [ ] Navigate directly to both the /home and /event pages as in Steps 2 and 3.
- - [ ] These should navigate to the desired pages without issue.   