### PR TITLE
Mg 125 topnav for loggedin

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,3 @@
-<app-topNav></app-topNav>
 <div class="container">
   <router-outlet></router-outlet>
 </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -20,6 +20,7 @@ export class AppComponent implements OnInit {
   userID = 'no User ID entered';
   movieRankings = new Map();
   highestRank = 'no highest rank';
+  
 
   constructor(public apicall: ApicallService, private router: Router) {
   }

--- a/src/app/auth.guard.ts
+++ b/src/app/auth.guard.ts
@@ -30,6 +30,7 @@ export class AuthGuard implements CanActivate {
     // for page refresh when logged in - AuthService wants to reset variables on a page refresh
     if (sessionStorage.getItem("hostID") !== null) {
       this.authService.isLoggedIn = true;
+      
     }
     console.log('checkLogin: isLoggedin=' + this.authService.isLoggedIn);
     if (this.authService.isLoggedIn) {

--- a/src/app/auth.service.ts
+++ b/src/app/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, Input } from '@angular/core';
 import { Observable, of } from 'rxjs';
 import { tap, delay } from 'rxjs/operators';
 import jwtDecode, { JwtPayload }  from "jwt-decode";
@@ -11,7 +11,7 @@ export interface JwtPayloadCognito extends JwtPayload {
   providedIn: 'root'
 })
 export class AuthService {
-  isLoggedIn = false;
+  @Input() isLoggedIn = false;
   redirectURL: string | null = null;
   idToken = '';
   accessToken = '';
@@ -46,7 +46,7 @@ export class AuthService {
       sessionStorage.setItem('id_token', this.idToken);
       sessionStorage.setItem('access_token', this.accessToken);
 
-      this.isLoggedIn = true;
+      //this.isLoggedIn = true;
 
       console.log("session storage-host: "+ sessionStorage.getItem('hostID'));
       console.log("session storage-idToken: " + sessionStorage.getItem('id_token')); 

--- a/src/app/event/event.component.html
+++ b/src/app/event/event.component.html
@@ -4,6 +4,7 @@
     <input matInput type="text" [(ngModel)]="hostID" />
   </mat-form-field>
 </p> -->
+<app-topNav></app-topNav>
 <p>Logged in HostID: {{ sessionhostID }}</p>
 
 <p>

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,3 +1,4 @@
+<app-topNav></app-topNav>
 <h1>Your Events</h1>
 <div class="logoutButton">
   <a

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,7 +1,9 @@
 <h1>Your Events</h1>
 <div class="logoutButton">
   <a
-    href="https://movie-meetup.auth.us-west-2.amazoncognito.com/logout?client_id=36c0irsvr5p4lbpkdoli72nk8p&logout_uri=http://localhost:4200/intro"
+    href="https://auth.moviemeetup.com/logout?client_id=3can93q53vqr18qoidsi1g65l7&logout_uri={{
+      logoutURL
+    }}"
     mat-raised-button
     color="warn"
     >LogOut</a

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -34,7 +34,6 @@ export class HomeComponent implements OnInit {
     console.log("session storage-host: "+ sessionStorage.getItem('hostID'));
     this.rankingService.loadMovieEventsByHostID(String(sessionStorage.getItem('hostID')));
     this.movieEvents = this.rankingService.getMovieEvents();
-  
     
   }
 

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -9,6 +9,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { filter } from 'rxjs/operators';
 
 
+
 export interface JwtPayloadCognito extends JwtPayload {
   preferred_username: string;
 }
@@ -21,6 +22,7 @@ export interface JwtPayloadCognito extends JwtPayload {
 
 export class HomeComponent implements OnInit {
   movieEvents: MovieEvent[] = [];
+  logoutURL= environment.logoutURL;
 
   constructor(public apicall: ApicallService, private router: Router, private rankingService: RankingService, private httpClient: HttpClient, private route: ActivatedRoute) {
     };
@@ -32,7 +34,8 @@ export class HomeComponent implements OnInit {
     console.log("session storage-host: "+ sessionStorage.getItem('hostID'));
     this.rankingService.loadMovieEventsByHostID(String(sessionStorage.getItem('hostID')));
     this.movieEvents = this.rankingService.getMovieEvents();
-   
+  
+    
   }
 
 }

--- a/src/app/intro/intro.component.html
+++ b/src/app/intro/intro.component.html
@@ -4,9 +4,17 @@
 <h3>To create a Movie Watch Event, login or sign up!</h3>
 <div class="introButton">
   <a
-    href="https://auth.moviemeetup.com/login?response_type=token&client_id=3can93q53vqr18qoidsi1g65l7&redirect_uri=http://localhost:4200/home"
+    href="https://auth.moviemeetup.com/login?response_type=token&client_id=3can93q53vqr18qoidsi1g65l7&redirect_uri={{
+      loginURL
+    }}"
     mat-raised-button
     color="primary"
     >LogIn/SignUp</a
   >
+  <!-- <a
+    href="https://movie-meetup.auth.us-west-2.amazoncognito.com/login?response_type=token&client_id=3can93q53vqr18qoidsi1g65l7&redirect_uri=http://localhost:4200/home"
+    mat-raised-button
+    color="primary"
+    >LogIn/SignUp</a
+  > -->
 </div>

--- a/src/app/intro/intro.component.html
+++ b/src/app/intro/intro.component.html
@@ -4,7 +4,7 @@
 <h3>To create a Movie Watch Event, login or sign up!</h3>
 <div class="introButton">
   <a
-    href="https://movie-meetup.auth.us-west-2.amazoncognito.com/login?response_type=token&client_id=36c0irsvr5p4lbpkdoli72nk8p&redirect_uri=http://localhost:4200/home"
+    href="https://auth.moviemeetup.com/login?response_type=token&client_id=3can93q53vqr18qoidsi1g65l7&redirect_uri=http://localhost:4200/home"
     mat-raised-button
     color="primary"
     >LogIn/SignUp</a

--- a/src/app/intro/intro.component.ts
+++ b/src/app/intro/intro.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { AuthService } from '../auth.service';
+import { environment } from '../../environments/environment';
 
 @Component({
   selector: 'app-intro',
@@ -7,6 +8,7 @@ import { AuthService } from '../auth.service';
   styleUrls: ['./intro.component.scss']
 })
 export class IntroComponent implements OnInit {
+  loginURL= environment.loginURL;
 
   constructor(private authService: AuthService) { }
 

--- a/src/app/topNav/topNav.component.html
+++ b/src/app/topNav/topNav.component.html
@@ -1,1 +1,3 @@
-<a routerLink="/home"><mat-icon>home</mat-icon></a>
+<div *ngIf="loggedUser">
+  <a routerLink="/home"><mat-icon>home</mat-icon></a>
+</div>

--- a/src/app/topNav/topNav.component.html
+++ b/src/app/topNav/topNav.component.html
@@ -1,3 +1,4 @@
-<div *ngIf="loggedUser">
+<!-- <div *ngIf="loggedUser">
   <a routerLink="/home"><mat-icon>home</mat-icon></a>
-</div>
+</div> -->
+<a routerLink="/home"><mat-icon>home</mat-icon></a>

--- a/src/app/topNav/topNav.component.ts
+++ b/src/app/topNav/topNav.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Input, ChangeDetectorRef } from '@angular/core';
 import { AuthService } from '../auth.service';
 import { AuthGuard } from '../auth.guard';
 import { Observable } from 'rxjs';
@@ -9,19 +9,28 @@ import { Observable } from 'rxjs';
   styleUrls: ['./topNav.component.css']
 })
 export class TopNavComponent implements OnInit {
-  public loggedUser = false;
+  loggedUser: boolean = false;
 
-  constructor(private authGuard: AuthGuard, private authService: AuthService) { }
+  constructor(private authGuard: AuthGuard, private authService: AuthService, private ref: ChangeDetectorRef) { }
+
   checkLoggedInStatus(): boolean {
     if (sessionStorage.getItem("hostID") !== null) {
-      this.loggedUser = true;
+      this.loggedUser = this.authService.isLoggedIn;
+      this.ref.detectChanges();
     }
-    console.log('topnav check: ' + this.loggedUser);
+    console.log('topnav checking: ' + this.loggedUser);
+    this.ref.detectChanges();
     return this.loggedUser;
   }
 
   ngOnInit(): void {
+    //this.checkLoggedInStatus();
+    this.loggedUser = this.authService.isLoggedIn;
+    console.log("topNav OnInit: loggedUser=" + this.loggedUser);
     this.checkLoggedInStatus();
+    console.log("topNav ngOnit: checkLoggedInStatus: "+ this.loggedUser);
+    this.ref.detectChanges();
+    
   }
   
 

--- a/src/app/topNav/topNav.component.ts
+++ b/src/app/topNav/topNav.component.ts
@@ -1,4 +1,7 @@
 import { Component, OnInit } from '@angular/core';
+import { AuthService } from '../auth.service';
+import { AuthGuard } from '../auth.guard';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-topNav',
@@ -6,10 +9,20 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./topNav.component.css']
 })
 export class TopNavComponent implements OnInit {
+  public loggedUser = false;
 
-  constructor() { }
+  constructor(private authGuard: AuthGuard, private authService: AuthService) { }
+  checkLoggedInStatus(): boolean {
+    if (sessionStorage.getItem("hostID") !== null) {
+      this.loggedUser = true;
+    }
+    console.log('topnav check: ' + this.loggedUser);
+    return this.loggedUser;
+  }
 
   ngOnInit(): void {
+    this.checkLoggedInStatus();
   }
+  
 
 }

--- a/src/app/topNav/topNav.component.ts
+++ b/src/app/topNav/topNav.component.ts
@@ -9,11 +9,11 @@ import { Observable } from 'rxjs';
   styleUrls: ['./topNav.component.css']
 })
 export class TopNavComponent implements OnInit {
-  loggedUser: boolean = false;
+  //loggedUser: boolean = false;
 
   constructor(private authGuard: AuthGuard, private authService: AuthService, private ref: ChangeDetectorRef) { }
 
-  checkLoggedInStatus(): boolean {
+  /* checkLoggedInStatus(): boolean {
     if (sessionStorage.getItem("hostID") !== null) {
       this.loggedUser = this.authService.isLoggedIn;
       this.ref.detectChanges();
@@ -21,15 +21,15 @@ export class TopNavComponent implements OnInit {
     console.log('topnav checking: ' + this.loggedUser);
     this.ref.detectChanges();
     return this.loggedUser;
-  }
+  } */
 
   ngOnInit(): void {
     //this.checkLoggedInStatus();
-    this.loggedUser = this.authService.isLoggedIn;
+    /* this.loggedUser = this.authService.isLoggedIn;
     console.log("topNav OnInit: loggedUser=" + this.loggedUser);
     this.checkLoggedInStatus();
     console.log("topNav ngOnit: checkLoggedInStatus: "+ this.loggedUser);
-    this.ref.detectChanges();
+    this.ref.detectChanges(); */
     
   }
   

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,5 @@
 export const environment = {
-  production: false
+  production: false,
+  loginURL: "https://moviemeetup.com/home",
+  logoutURL: "https://moviemeetup.com/intro"
 };


### PR DESCRIPTION
This addresses Issue #125 (Update Topnav to not show for non-logged in users), as well as includes updates for Cognito login/logout button urls.

As a developer, I want to have a TopNav button only display for users who are logged in and would need to access the home page and the build event page.  Non-logged in users visiting the intro, rankings, and final rankings pages do not need a topnav button that takes them to a home page they have to log in to see.

The solution for this currently is to remove the topnav component from app.component.ts, and hard code it directly into the home.component.html and event.componenthtml pages.

Addtionally, this PR also includes finalized congnito urls for the login and logout buttons, including env variables that can be referenced. this makes it so the env files are the only thing changing between dev and prod, and the url code remains the same for each.

To verify:
- [x] launch app, arriving on the /intro page.
- [x] Verify there is no topnav icon.
- [x] sign in with a test user account, and arrive on the /home page. 
- [x] Verify there now is a topnav icon.
- [x] Click "create Event" button, and arrive on the /event page.
- [x] Verify there is still a topnav button.
- [x] Click the topnav icon and return to /home.
- [x] Assuming your test account has events created, click one of the test buttons for Rankings.
- [x] Verify there is no Topnav icon.
- [x] using the back arrow or adjusting the url to be "/home", return to the home page.
- [x] Assuming your test account has events created, clikc one of the test buttons for Final Rankings.
- [ ] Verify there is no Topnav icon.

