### PR TITLE
Mg 123 home page event table

### DIFF
--- a/src/app/apicall.service.ts
+++ b/src/app/apicall.service.ts
@@ -128,5 +128,4 @@ export class ApicallService {
         })
       )
   }
-
 }

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -12,7 +12,7 @@
 </div>
 <a mat-raised-button color="primary" routerLink="/event">Build an Event</a>
 <h2>Click on a link below to go to your Events</h2>
-<div *ngFor="let event of movieEvents">
+<!-- <div *ngFor="let event of movieEvents">
   <a mat-raised-button color="warn" [routerLink]="['/ranking', event.id]">{{
     event.eventTitle
   }}</a>
@@ -25,27 +25,56 @@
     [routerLink]="['/finalranking', event.id]"
     >{{ event.eventTitle }}</a
   >
-</div>
+</div> -->
 
 <!-- TABLE TO DISPLAY CREATED EVENTS -->
-<!--<div class="col-md-12">
+<div class="col-md-12">
   <table class="table table-bordered">
     <thead>
       <tr>
-        <th scope="col">Event ID</th>
-        <th scope="col">Host ID</th>
+        <!-- <th scope="col">Event ID</th> -->
         <th scope="col">Event Name</th>
         <th scope="col">Date</th>
+        <th scope="col">Movies</th>
+        <th scope="col">Votes Submitted</th>
+        <th scope="col">Invite Guests</th>
       </tr>
     </thead>
     <tbody>
       <tr *ngFor="let viewing of movieEvents">
-        <td>{{ viewing.id}}</td>
-        <td>{{ viewing.hostID}}</td>
-        <td>{{ viewing.eventTitle }}</td>
+        <!-- <td>{{ viewing.id }}</td> -->
+        <td>
+          <a
+            mat-raised-button
+            color="warn"
+            [routerLink]="['/ranking', viewing.id]"
+            >{{ viewing.eventTitle }}</a
+          >
+        </td>
         <td>{{ viewing.eventDate }}</td>
+        <td>
+          <ul *ngFor="let movie of viewing.eventMovies">
+            <li>{{ movie.title }}</li>
+          </ul>
+        </td>
+        <td *ngIf="viewing.eventRankings; else dispZero">
+          {{ viewing.eventRankings?.length }}
+        </td>
+        <ng-template #dispZero>0</ng-template>
+        <td>
+          <a
+            href="mailto:?subject=Vote%20for%20which%20movie%20to%20watch%20for%20'{{
+              viewing.eventTitle
+            }}'&body=Before%20{{
+              viewing.eventDate
+            }},%20rank%20the%20movies%20at:%0A%0A{{ this.url }}{{
+              viewing.id
+            }}%0A%0AThanks!"
+          >
+            email
+          </a>
         </td>
       </tr>
     </tbody>
   </table>
-</div>-->
+</div>

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -35,6 +35,7 @@ export class HomeComponent implements OnInit {
     this.rankingService.loadMovieEventsByHostID(String(sessionStorage.getItem('hostID')));
     this.movieEvents = this.rankingService.getMovieEvents();
     
+    
   }
 
 }

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -23,6 +23,7 @@ export interface JwtPayloadCognito extends JwtPayload {
 export class HomeComponent implements OnInit {
   movieEvents: MovieEvent[] = [];
   logoutURL= environment.logoutURL;
+  url = 'https://moviemeetup.com/ranking/';
 
   constructor(public apicall: ApicallService, private router: Router, private rankingService: RankingService, private httpClient: HttpClient, private route: ActivatedRoute) {
     };
@@ -35,7 +36,6 @@ export class HomeComponent implements OnInit {
     this.rankingService.loadMovieEventsByHostID(String(sessionStorage.getItem('hostID')));
     this.movieEvents = this.rankingService.getMovieEvents();
 
-    console.log("TEST: " + this.movieEvents);
     
     
   }

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -34,6 +34,8 @@ export class HomeComponent implements OnInit {
     console.log("session storage-host: "+ sessionStorage.getItem('hostID'));
     this.rankingService.loadMovieEventsByHostID(String(sessionStorage.getItem('hostID')));
     this.movieEvents = this.rankingService.getMovieEvents();
+
+    console.log("TEST: " + this.movieEvents);
     
     
   }

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,7 +3,11 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-    production: false
+  production: false,
+  imdbApiKey: "k_jr9zca59",
+  demoUserID: "DEMO",
+  loginURL: "http://localhost:4200/home",
+  logoutURL: "http://localhost:4200/intro"
 };
   
   /*


### PR DESCRIPTION
for Issue #123 -- adding a table to the home page, showing all events created by the logged in hostID.

As a User, I want to see the events I've created when I sign in including the name and date of the event with the selected movies visible, and I want to see how many users have voted for the movies so far. I also want a handy link in which to email people to rank the movies for each event.  The name of each event is a button that goes to the rankings page for the  event.

I have also commented out the test buttons we were using for rankings and final rankings. Additional css table stylings will be added very soon.

Tested on Win10 laptop, Chrome v92.

To Verify:

- [x] Log in to the app, with a account that has events created (DEMO or loki, for example). You will be directed to the home page.
- [x] Take a look at the table.

![image](https://user-images.githubusercontent.com/49133101/132817989-9bd60e1f-725c-4a21-b31c-69fcabab5620.png)
