### PR TITLE
Kj 112 final rankings tie

### DIFF
--- a/src/app/finalRanking/final-ranking.component.html
+++ b/src/app/finalRanking/final-ranking.component.html
@@ -1,45 +1,47 @@
-<h1>Event Title: {{ eventTitle }}</h1>
-<h2>Event Date: {{ eventDate }}</h2>
+<div class="container">
+  <h1>{{ eventTitle }} on {{ eventDate }}</h1>
+  <!--<h2>{{ eventDate }}</h2>-->
 
-<h3>The Top Selected Movie Is...</h3>
-
-<ng-container *ngIf="finalRankings">
-  <div class="content">
-    <div class="cardHeader">
-      {{ finalRankings[0].title }}
-    </div>
-    <mat-card *ngIf="rankings" class="movie-card">
-      <!--<div class="content" *ngIf="finalRankings">
-        <app-movie-card [movie]="finalRankings[0]"> </app-movie-card>
-      </div>-->
-      <div class="content">
-        <img
-          mat-card-image
-          src="{{ finalRankings[0].image }}"
-          alt="Movie Poster for {{ finalRankings[0].title }}"
-        />
+  <h3>Top Selected Movie(s):</h3>
+  <ng-container *ngIf="finalRankings">
+    <div class="content">
+      <div class="cardHeader">
+        {{ topChoices }}
+        <!--{{ finalRankings[0].title }}-->
       </div>
-    </mat-card>
-  </div>
-</ng-container>
+      <mat-card *ngIf="rankings" class="movie-card">
+        <!--<div class="content" *ngIf="finalRankings">
+          <app-movie-card [movie]="finalRankings[0]"> </app-movie-card>
+        </div>-->
+        <div class="content">
+          <img
+            mat-card-image
+            src="{{ finalRankings[0].image }}"
+            alt="Movie Poster for {{ finalRankings[0].title }}"
+          />
+        </div>
+      </mat-card>
+    </div>
+  </ng-container>
 
-<h3>Final Rankings:</h3>
-<div class="col-md-12">
-  <table class="table table-bordered">
-    <thead>
-      <tr>
-        <th scope="col">Movie Title</th>
-        <th scope="col">Points</th>
-      </tr>
-    </thead>
-    <tbody>
-      <ng-container *ngIf="rankings">
-        <tr *ngFor="let movie of finalRankings; let i = index">
-          <td>{{ movie.title }}</td>
-          <td class="points">{{ movie.points }}</td>
+  <h3>Final Rankings:</h3>
+  <div class="col-md-12">
+    <table class="table table-bordered">
+      <thead>
+        <tr>
+          <th scope="col">Movie Title</th>
+          <th scope="col">Points</th>
         </tr>
-      </ng-container>
-    </tbody>
-  </table>
+      </thead>
+      <tbody>
+        <ng-container *ngIf="rankings">
+          <tr *ngFor="let movie of finalRankings; let i = index">
+            <td>{{ movie.title }}</td>
+            <td class="points">{{ movie.points }}</td>
+          </tr>
+        </ng-container>
+      </tbody>
+    </table>
+  </div>
 </div>
 

--- a/src/app/finalRanking/final-ranking.component.html
+++ b/src/app/finalRanking/final-ranking.component.html
@@ -5,6 +5,9 @@
   <h3>Top Selected Movie(s):</h3>
   <ng-container *ngIf="finalRankings">
     <div class="content">
+      <div *ngIf="topChoices.length > 1">
+        There is a {{ topChoices.length }}-way tie!
+      </div>
       <div class="cardHeader">
         {{ topChoices }}
         <!--{{ finalRankings[0].title }}-->

--- a/src/app/finalRanking/final-ranking.component.scss
+++ b/src/app/finalRanking/final-ranking.component.scss
@@ -1,25 +1,10 @@
+h1 {
+  padding-bottom: 10px;
+}
+
 h3 {
   text-align: center;
-}
-
-.cardHeader {
-  text-align: center;
-  margin: 16px;
-  font-size: medium;
-  font-weight: bold;
-  padding: 20px;
-  overflow-wrap: normal;
-}
-
-.movie-card {
-  //padding: auto;
-  width: 250px;
-  height: 450px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background-color: #f5f5f5;
-  margin: auto;
+  padding-top: 20px;
 }
 
 img {
@@ -35,6 +20,33 @@ img {
 table {
   margin-left: auto;
   margin-right: auto;
+}
+
+.cardHeader {
+  text-align: center;
+  margin: 16px;
+  font-size: medium;
+  font-weight: bold;
+  padding: 20px;
+  overflow-wrap: normal;
+}
+
+.container {
+  display: block;
+  text-align: center;
+  margin: auto;
+  max-width: 500px;
+}
+
+.movie-card {
+  //padding: auto;
+  width: 250px;
+  height: 450px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: #f5f5f5;
+  margin: auto;
 }
 
 .points {

--- a/src/app/finalRanking/final-ranking.component.ts
+++ b/src/app/finalRanking/final-ranking.component.ts
@@ -34,6 +34,7 @@ export class FinalRankingComponent implements OnInit {
   finalRanking = new Map();
   userRankings: RankUpdate[] = [];
   data: any;
+  tiedMovies: String[] = [];
 
   constructor(
     public apicall: ApicallService, 
@@ -72,6 +73,17 @@ export class FinalRankingComponent implements OnInit {
       if (this.movieEvent.id) {
         this.id = this.movieEvent.id;
         this.url = this.url + this.id;
+      }
+      this.checkPointTie();
+    }
+  }
+
+  checkPointTie() {
+    let max = this.finalRankings[0].points;
+    for (let finalRanking in this.finalRankings) {
+      if (max == this.finalRankings[finalRanking].points) {
+        this.tiedMovies.push(this.finalRankings[finalRanking].title);
+        console.log("tied movies: ", this.tiedMovies);
       }
     }
   }

--- a/src/app/finalRanking/final-ranking.component.ts
+++ b/src/app/finalRanking/final-ranking.component.ts
@@ -34,7 +34,7 @@ export class FinalRankingComponent implements OnInit {
   finalRanking = new Map();
   userRankings: RankUpdate[] = [];
   data: any;
-  tiedMovies: String[] = [];
+  topChoices: String[] = [];
 
   constructor(
     public apicall: ApicallService, 
@@ -82,8 +82,8 @@ export class FinalRankingComponent implements OnInit {
     let max = this.finalRankings[0].points;
     for (let finalRanking in this.finalRankings) {
       if (max == this.finalRankings[finalRanking].points) {
-        this.tiedMovies.push(this.finalRankings[finalRanking].title);
-        console.log("tied movies: ", this.tiedMovies);
+        this.topChoices.push(" " + this.finalRankings[finalRanking].title);
+        console.log("top choices: ", this.topChoices);
       }
     }
   }

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -12,7 +12,7 @@
 </div>
 <a mat-raised-button color="primary" routerLink="/event">Build an Event</a>
 <h2>Click on a link below to go to your Events</h2>
-<!-- <div *ngFor="let event of movieEvents">
+<div *ngFor="let event of movieEvents">
   <a mat-raised-button color="warn" [routerLink]="['/ranking', event.id]">{{
     event.eventTitle
   }}</a>
@@ -25,7 +25,7 @@
     [routerLink]="['/finalranking', event.id]"
     >{{ event.eventTitle }}</a
   >
-</div> -->
+</div>
 
 <!-- TABLE TO DISPLAY CREATED EVENTS -->
 <div class="col-md-12">


### PR DESCRIPTION
# Description
As a User, when multiple movies tie for the highest point value, I want to be shown all of the tying movie titles so I know there is a tie without looking at the final rankings. As a User, I would also like the layout to be centered so it is more visually aligned with the rest of the website.
Closes #112

Event with tied movies
<img width="1023" alt="Screen Shot 2021-09-10 at 6 45 34 AM" src="https://user-images.githubusercontent.com/26866132/132863420-cb096151-048b-4f2b-8bae-f2de9db6218b.png">

Event without tied movies
<img width="1039" alt="Screen Shot 2021-09-10 at 6 44 06 AM" src="https://user-images.githubusercontent.com/26866132/132863515-dda997bc-95f6-44e2-8e38-b98d61f3c0cd.png">

# Tested
MacOS Big Sur on Chrome Browser

# Testing
- [ ] Navigate to Home page after Logging in from current Intro page
- [ ] Click on the FinalRanking test button for any preexisting or newly created movieEvent that has a tie. (Logging into test account Kristin.jue+DEMO@gmail.com with the test password and clicking on the event with the title "TestingPR" will take you to the event with tying top movie selections as depicted in this screenshot.)
- [ ] View the FinalRankings page with the multiple top selected movies.
- [ ] Navigate back to Home page using the back browser navigation or going to /home.
- [ ] Click on any other Event without tying movies
- [ ] VIew the FinalRankings page without multiple top selected movies (aka only one top selected movie).