### PR TITLE
Mg 146 event form fixed to top

### DIFF
--- a/src/app/event/event.component.html
+++ b/src/app/event/event.component.html
@@ -4,43 +4,46 @@
     <input matInput type="text" [(ngModel)]="hostID" />
   </mat-form-field>
 </p> -->
-<app-topNav></app-topNav>
-<p>Logged in HostID: {{ sessionhostID }}</p>
+<div class="fixedHead">
+  <app-topNav></app-topNav>
 
-<p>
-  <mat-form-field appearance="fill">
-    <mat-label>Enter Event Title</mat-label>
-    <input matInput type="text" [(ngModel)]="eventTitle" />
-    <!--<mat-error>{{ getErrorMessage() }}</mat-error>-->
-  </mat-form-field>
-</p>
+  <p>Logged in HostID: {{ sessionhostID }}</p>
 
-<mat-form-field appearance="fill">
-  <mat-label>Choose a Date</mat-label>
-  <input
-    matInput
-    [min]="minDate"
-    [matDatepicker]="picker"
-    (dateInput)="setDate($event)"
-  />
-  <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
-  <mat-datepicker #picker></mat-datepicker>
-</mat-form-field>
-
-<h3>Click on at least three Movies below to select them for your Event</h3>
-
-<h3 style="color: red">
-  {{ errormsg }}
-</h3>
-<div class="createBox">
   <p>
-    <button mat-raised-button color="primary" (click)="createEvent()">
-      Create Event
-    </button>
+    <mat-form-field appearance="fill">
+      <mat-label>Enter Event Title</mat-label>
+      <input matInput type="text" [(ngModel)]="eventTitle" />
+      <!--<mat-error>{{ getErrorMessage() }}</mat-error>-->
+    </mat-form-field>
   </p>
-  <p *ngIf="confirmed" class="confirmation" style="color: green">
-    <strong>{{ confmsg }}</strong>
-  </p>
+
+  <mat-form-field appearance="fill">
+    <mat-label>Choose a Date</mat-label>
+    <input
+      matInput
+      [min]="minDate"
+      [matDatepicker]="picker"
+      (dateInput)="setDate($event)"
+    />
+    <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+    <mat-datepicker #picker></mat-datepicker>
+  </mat-form-field>
+
+  <h3>Click on at least three Movies below to select them for your Event</h3>
+
+  <h3 style="color: red">
+    {{ errormsg }}
+  </h3>
+  <div class="createBox">
+    <p>
+      <button mat-raised-button color="primary" (click)="createEvent()">
+        Create Event
+      </button>
+    </p>
+    <p *ngIf="confirmed" class="confirmation" style="color: green">
+      <strong>{{ confmsg }}</strong>
+    </p>
+  </div>
 </div>
 
 <!-- TABLE TO DISPLAY CREATED EVENTS -->

--- a/src/app/event/event.component.html
+++ b/src/app/event/event.component.html
@@ -4,9 +4,10 @@
     <input matInput type="text" [(ngModel)]="hostID" />
   </mat-form-field>
 </p> -->
-<div class="fixedHead">
+<div class="fixedNav">
   <app-topNav></app-topNav>
-
+</div>
+<div class="fixedHead">
   <p>Logged in HostID: {{ sessionhostID }}</p>
 
   <p>
@@ -51,20 +52,20 @@
   <table class="table table-bordered">
     <thead>
       <tr>
-        <th scope="col">Host ID</th>
         <th scope="col">Event Name</th>
         <th scope="col">Date</th>
         <th scope="col">Movies Selected</th>
+        <th scope="col">Votes Returned</th>
       </tr>
     </thead>
     <tbody>
       <tr *ngFor="let viewing of events | keyvalue">
-        <td>{{ viewing.value.hostID }}</td>
         <td>{{ viewing.value.eventTitle }}</td>
         <td>{{ viewing.value.eventDate }}</td>
         <h2 *ngFor="let selectedMovie of viewing.value.selectedMovies">
           <h4>{{ selectedMovie.title }}</h4>
         </h2>
+        
         <mat-divider></mat-divider>
       </tr>
     </tbody>
@@ -76,7 +77,7 @@
   <div fxLayout="row wrap" fxLayoutGap="16px grid">
     <div class="content" *ngFor="let movie of eventMovies">
       <app-movie-card [movie]="movie"> </app-movie-card>
-      <div>{{ movie.title }}</div>
+      <div class="movieTitle">{{ movie.title }}</div>
     </div>
   </div>
 </div>

--- a/src/app/event/event.component.html
+++ b/src/app/event/event.component.html
@@ -10,25 +10,27 @@
 <div class="fixedHead">
   <p>Logged in HostID: {{ sessionhostID }}</p>
 
-  <p>
-    <mat-form-field appearance="fill">
-      <mat-label>Enter Event Title</mat-label>
-      <input matInput type="text" [(ngModel)]="eventTitle" />
-      <!--<mat-error>{{ getErrorMessage() }}</mat-error>-->
-    </mat-form-field>
-  </p>
+  <div class="desktop">
+    <p>
+      <mat-form-field appearance="fill">
+        <mat-label>Enter Event Title</mat-label>
+        <input matInput type="text" [(ngModel)]="eventTitle" />
+        <!--<mat-error>{{ getErrorMessage() }}</mat-error>-->
+      </mat-form-field>
+    </p>
 
-  <mat-form-field appearance="fill">
-    <mat-label>Choose a Date</mat-label>
-    <input
-      matInput
-      [min]="minDate"
-      [matDatepicker]="picker"
-      (dateInput)="setDate($event)"
-    />
-    <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
-    <mat-datepicker #picker></mat-datepicker>
-  </mat-form-field>
+    <mat-form-field appearance="fill">
+      <mat-label>Choose a Date</mat-label>
+      <input
+        matInput
+        [min]="minDate"
+        [matDatepicker]="picker"
+        (dateInput)="setDate($event)"
+      />
+      <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+      <mat-datepicker #picker></mat-datepicker>
+    </mat-form-field>
+  </div>
 
   <h3>Click on at least three Movies below to select them for your Event</h3>
 

--- a/src/app/event/event.component.scss
+++ b/src/app/event/event.component.scss
@@ -1,16 +1,40 @@
 mat-toolbar {
   justify-content: space-between;
+  padding-top: 0px;
+}
+* {
+  justify-content: center;
+  text-align: center;
 }
 
 body {
-  padding-top: 0px;
+  padding: 0em 1em;
+}
+
+app-topnav {
+  justify-content: left;
+}
+
+mat-datepicker-toggle {
+  z-index: 9999;
+}
+
+.fixedNav {
+  position: sticky;
+  top: 0;
+  padding-top: 15px;
+  margin: 0em -1.5em auto;
+  background-color: white;
+  z-index: 1;
+  text-align: left;
 }
 
 .fixedHead {
   position: sticky;
-  top: 0;
-  margin: 0 auto;
-  z-index: 9999;
+  top: 40px;
+  margin: 0em -1.5em auto;
+  z-index: 1;
+  padding-top: 5px;
   background-color: white;
   border-bottom: 1px solid blue;
 }
@@ -42,8 +66,23 @@ body {
 }
 
 .movieTitle {
-  font-size: medium;
+  font-size: smaller;
   font-weight: bold;
-  padding: 20px;
+  padding: 10px 0px;
   word-wrap: normal;
+}
+
+@media only screen and (max-width: 600px) {
+  .movie-card {
+    //padding: auto;
+    width: 125px;
+    height: 225px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .movieTitle {
+    font-size: x-small;
+  }
 }

--- a/src/app/event/event.component.scss
+++ b/src/app/event/event.component.scss
@@ -57,11 +57,11 @@ mat-datepicker-toggle {
 }
 
 .createBox p {
-  display: inline-block;
+  display: block;
 }
 
 .confirmation {
-  margin-left: 2em;
+  margin: 1em;
   font-size: 1.25rem;
 }
 

--- a/src/app/event/event.component.scss
+++ b/src/app/event/event.component.scss
@@ -2,6 +2,19 @@ mat-toolbar {
   justify-content: space-between;
 }
 
+body {
+  padding-top: 0px;
+}
+
+.fixedHead {
+  position: sticky;
+  top: 0;
+  margin: 0 auto;
+  z-index: 9999;
+  background-color: white;
+  border-bottom: 1px solid blue;
+}
+
 .clickable {
   cursor: pointer;
 }

--- a/src/app/event/event.component.scss
+++ b/src/app/event/event.component.scss
@@ -12,7 +12,7 @@ body {
 }
 
 app-topnav {
-  justify-content: left;
+  text-align: revert;
 }
 
 mat-datepicker-toggle {
@@ -34,9 +34,9 @@ mat-datepicker-toggle {
   top: 40px;
   margin: 0em -1.5em auto;
   z-index: 1;
-  padding-top: 5px;
+  padding-top: 0px;
   background-color: white;
-  border-bottom: 1px solid blue;
+  border-bottom: 1px solid #3f51b5;
 }
 
 .clickable {

--- a/src/app/event/event.component.scss
+++ b/src/app/event/event.component.scss
@@ -86,3 +86,10 @@ mat-datepicker-toggle {
     font-size: x-small;
   }
 }
+
+@media only screen and (min-width: 900px) {
+  .desktop {
+    display: flex;
+    justify-content: space-evenly;
+  }
+}

--- a/src/app/finalRanking/final-ranking.component.scss
+++ b/src/app/finalRanking/final-ranking.component.scss
@@ -1,5 +1,5 @@
 h1 {
-  padding-bottom: 10px;
+  padding: 10px 0px;
 }
 
 h3 {

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,4 +1,6 @@
-<app-topNav></app-topNav>
+<div class="nav">
+  <app-topNav></app-topNav>
+</div>
 <!--<div class="logoutButton">
   <a
     href="https://auth.moviemeetup.com/logout?client_id=3can93q53vqr18qoidsi1g65l7&logout_uri={{

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -28,24 +28,25 @@
 </div>
 
 <!-- TABLE TO DISPLAY CREATED EVENTS -->
-<!--<div class="col-md-12">
+<!-- <div class="col-md-12">
   <table class="table table-bordered">
     <thead>
       <tr>
-        <th scope="col">Event ID</th>
-        <th scope="col">Host ID</th>
         <th scope="col">Event Name</th>
         <th scope="col">Date</th>
+        <th scope="col">Movies</th>
+        <th scope="col">Votes Submitted</th>
+        <th scope="col">Voters</th>
       </tr>
     </thead>
     <tbody>
       <tr *ngFor="let viewing of movieEvents">
-        <td>{{ viewing.id}}</td>
-        <td>{{ viewing.hostID}}</td>
         <td>{{ viewing.eventTitle }}</td>
         <td>{{ viewing.eventDate }}</td>
-        </td>
+        <td>{{ viewing.eventMovies }}</td>
+        <td>{{ viewing.eventRankings?.length }}</td>
+        <td>{{ viewing.eventRankings?.UserRankings?.userID }}</td>
       </tr>
     </tbody>
   </table>
-</div>-->
+</div> -->

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -1,3 +1,12 @@
+.nav {
+  padding-top: 15px;
+  margin: 0em -1.5em auto;
+}
+
+h1 {
+  padding-top: 1em;
+}
+
 h2 {
   padding: 30px;
 }

--- a/src/app/movieCard/movieCard.component.scss
+++ b/src/app/movieCard/movieCard.component.scss
@@ -1,7 +1,7 @@
 .movie-card {
   //padding: auto;
-  width: 250px;
-  height: 450px;
+  width: 188px;
+  height: 338px;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/app/ranking/ranking.component.scss
+++ b/src/app/ranking/ranking.component.scss
@@ -59,5 +59,6 @@ h1 {
 
 button {
   margin: 0 auto;
+  margin-top: 1em;
   display: block;
 }

--- a/src/app/ranking/ranking.component.scss
+++ b/src/app/ranking/ranking.component.scss
@@ -1,3 +1,12 @@
+* {
+  justify-content: center;
+  text-align: center;
+}
+
+h1 {
+  padding-top: 1em;
+}
+
 .example-list {
   width: 500px;
   max-width: 100%;
@@ -7,6 +16,7 @@
   background: white;
   border-radius: 4px;
   overflow: hidden;
+  margin: 0 auto;
 }
 
 .example-box {
@@ -27,8 +37,7 @@
   box-sizing: border-box;
   border-radius: 4px;
   box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
-  0 8px 10px 1px rgba(0, 0, 0, 0.14),
-  0 3px 14px 2px rgba(0, 0, 0, 0.12);
+    0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12);
   max-width: 20%;
 }
 
@@ -46,4 +55,9 @@
 
 .example-list.cdk-drop-list-dragging .example-box:not(.cdk-drag-placeholder) {
   transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+}
+
+button {
+  margin: 0 auto;
+  display: block;
 }

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,7 +3,11 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-    production: false
+  production: false,
+  imdbApiKey: "k_jr9zca59",
+  demoUserID: "DEMO",
+  loginURL: "http://localhost:4200/home",
+  logoutURL: "http://localhost:4200/intro"
 };
   
   /*

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,9 +1,9 @@
-@import '~@angular/material/prebuilt-themes/indigo-pink.css';
+@import "~@angular/material/prebuilt-themes/indigo-pink.css";
 
 body {
   font-family: Roboto, Arial, sans-serif;
   margin: 0;
-  padding: 30px;
+  padding: 0px 30px 30px 30px;
 }
 
 .version-info {
@@ -11,4 +11,3 @@ body {
   float: right;
   margin: 8px;
 }
-


### PR DESCRIPTION
Resolves issues #146.

As a user, I want to be able to scroll through the movie options and still easily access the create event form elements and create event button, so I can examine all movies and not have to scroll all the way back to the top in order to complete my event creation. The form elements and submit button should remain visible along the top of the page.

As a developer, I want my home icon to appear in the same place on both the home page and the event page. I want all pages to have centered text alignment. I want the event form elements to take up less space when in a desktop viewing format.

Tested on Win10 laptop, Chrome v92.

To verify:

- [x] Log in to the app with a test account. Arrive on the home page.  Note the margins and placement of the home icon.
![image](https://user-images.githubusercontent.com/49133101/132912757-000c04ec-94ab-4c4f-98c5-06fa983c764f.png)

- [x] Select an Orange ranking button for a pre-created event to navigate to the rankings page. Observe the centering of page elements:
![image](https://user-images.githubusercontent.com/49133101/132913272-47efda23-2546-47a2-9264-73fbfdd0079f.png)

- [x] Go back to the home page and select the "buid event" button to go to the event page.  On a desktop view, note the placement of the home icon is the same as the home page, and the form elements are side by side.
- [x] You can also scroll through the movies and see the header remain in place, while the movie posters will scroll behind it.
- [x] Also note that selecting the datepicker will have the calendar appear above the header.
![image](https://user-images.githubusercontent.com/49133101/132913757-f4373c01-2d47-4404-a6ae-880bdbbccc24.png)


- [x] Adjust your view to be less than 900 pixels to see the header revert to a stacked layout:
![image](https://user-images.githubusercontent.com/49133101/132913864-23e8624e-8200-46eb-ba68-1279e69900c9.png)

