### PR TITLE
Mg 151 responsive event table

### DIFF
--- a/src/app/event.service.ts
+++ b/src/app/event.service.ts
@@ -31,6 +31,13 @@ export class EventService {
     console.log(this.movies);
   }
 
+  resetMovieArray() {
+    this.movies.length = 0;
+    console.log("selected movies cleared");
+    return this.movies;
+    
+  }
+
 }
 
 

--- a/src/app/event/event.component.ts
+++ b/src/app/event/event.component.ts
@@ -138,7 +138,7 @@ export class EventComponent implements OnInit {
     this.eventDate = '';
     this.errormsg = '';
     this.date = new FormControl(new Date());
-    this.selectedMovies = [];
+    this.eventService.resetMovieArray();
     this.confmsg = `Your "${newEvent.eventTitle}" event has been created!`;
     this.confmessage();
     //return newEvent;

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -60,7 +60,9 @@
         <td *ngIf="viewing.eventRankings; else dispZero">
           {{ viewing.eventRankings?.length }}
         </td>
-        <ng-template #dispZero>0</ng-template>
+        <ng-template #dispZero>
+          <td>0</td>
+        </ng-template>
         <td>
           <a
             href="mailto:?subject=Vote%20for%20which%20movie%20to%20watch%20for%20'{{

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -59,7 +59,6 @@
             <ul *ngFor="let movie of viewing.eventMovies">
               <li>{{ movie.title }}</li>
             </ul>
-            <mat-divider></mat-divider>
           </td>
           <td *ngIf="viewing.eventRankings; else dispZero">
             {{ viewing.eventRankings?.length }}

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -3,3 +3,104 @@
   justify-content: center;
   align-items: center;
 }
+
+/* RESPONSIVE TABLE CSS */
+table {
+  border: 1px solid #000;
+  width: 90%;
+  margin: 2em auto;
+  border-collapse: collapse;
+  /* font-family: "Titillium Web", sans-serif; */
+}
+
+caption {
+  margin: 0.5em;
+  font-weight: 700;
+  font-size: 1.25em;
+}
+thead,
+th {
+  background-color: #000;
+  color: #fff;
+  border: 2px solid #fff;
+  padding: 0.6em;
+}
+
+tr {
+  vertical-align: top;
+}
+
+tr:nth-child(even) {
+  background-color: rgba(198, 210, 255, 0.898);
+}
+
+td {
+  border: 1px solid #000;
+  padding: 0.5em;
+  vertical-align: middle;
+}
+
+/* TABLE CSS FOR SMALLER SCREENS */
+@media all and (max-width: 850px) {
+  table,
+  thead,
+  tbody,
+  th,
+  td,
+  tr,
+  caption {
+    display: block;
+    border: 0px;
+  }
+
+  table {
+    border-collapse: collapse;
+  }
+
+  table.client {
+    width: 90%;
+  }
+
+  thead {
+    display: none;
+  }
+
+  tr {
+    border: 2px solid rgba(0, 8, 8, 0);
+  }
+
+  td {
+    border: 1px solid #000;
+    position: relative;
+    text-align: center;
+    padding-left: 90px;
+  }
+
+  td::before {
+    position: absolute;
+    left: 6px;
+    width: 45%;
+    padding-right: 10px;
+    white-space: nowrap;
+    text-align: left;
+  }
+
+  td:nth-of-type(1):before {
+    content: "Event Name:";
+  }
+
+  td:nth-of-type(2):before {
+    content: "Date:";
+  }
+
+  td:nth-of-type(3):before {
+    content: "Movies:";
+  }
+
+  td:nth-of-type(4):before {
+    content: "Votes Submitted:";
+  }
+  td:nth-of-type(5):before {
+    content: "Invite Guests:";
+  }
+}


### PR DESCRIPTION
Resolves issue #151 and #150 

As a User, I want to be able to see the Home Page's event info table easily on either a desktop or on Mobile, so I can easily see the info in a cohesive way on any device.

Tested on win10 laptop, Chrome v92.

To verify:

- [x] Log in to the app with a test account with created events. When on the home page on desktop see the table css:
![image](https://user-images.githubusercontent.com/49133101/132924195-101284d7-135b-4dec-ba0d-0854a993cd6e.png)

- [x] Note the "0" User Rankings is now centrally aligned like the other submitted votes numbers. Note the arrangement of the table elements.
- [x] Inspect the page, and adjust the pixel size to be less than 850px. Not the table layout changes to fit on smaller screens.  This works as far down into the 300 pixel range:
![image](https://user-images.githubusercontent.com/49133101/132924342-184587c0-9922-4a4d-b843-2662c35cc6a0.png)
