### PR TITLE
Mg 76 created event clear array

### DIFF
--- a/src/app/event/event.component.ts
+++ b/src/app/event/event.component.ts
@@ -171,47 +171,4 @@ export class IterablePipe implements PipeTransform {
   }
 }
 
-// methods needed:
-  // create new event (constructor)
-      // creates event with an id and date (date picker?) required.
 
-  // search for movies
-      // moves to searching for movies to add.
-          // would need to have add button for each movie object in table
-              // add button would add movie to eventMovie array
-  // add invitees to invitees
-  // find existing event
-  // update existing event
-  // update movieRankings (when invitee does their ranking)
-
-
-// Event JSON
-  /* "eventID": "string",
-	"eventDate": "string",
-	"movies": [
-		{
-			"movieID": "string",
-			"image": "string",
-			"title": "string",
-			"description": "string"
-		}
-	],
-	"invitees": [
-		{
-			"userID": "string",
-			"firstName": "string",
-			"lastName": "string",
-			"email": "string",
-			"rankDone": "boolean"
-		}
-	],
-	"rankings": [
-		{
-			"userID": "string",
-			"rankedMovies": {
-				"movieID": "string",
-				"title": "string",
-				"score": "number"
-			}
-		}
-	] */


### PR DESCRIPTION
This resolves Issue #76 .

As a User, I want to ensure the array of selected movies is cleared after I select the "Create Event" button, so that if want to create multiple events while on the Event page, I don't get previous event's selections concatenated onto subsequent events.

Tested on Win10 laptop, Chrome v92

To Verify:

- [x] Sign into app with a test or newly creater hostID user.
- [x] On the home page, select "Build Event" button.
- [x] On the Event page, fill in the event name, select a date, and select at least 3 movies. Then hit the "Create Event" button.
- - [x] In the console logs, you should see "selected movies cleared":
![image](https://user-images.githubusercontent.com/49133101/132928046-fd45435e-4462-4eeb-bacb-ce2731e6c5bb.png)
 
- [x] After the green confirmation message goes away, enter in a new event title and select a new event date, but do not select any movies. Select the "Create Event" button.  
- [x] You should get the red warning message about needing to select at least 3 movies:
![image](https://user-images.githubusercontent.com/49133101/132928124-14e3373a-5eb1-4e78-be76-299606451c7e.png)
