### PR TITLE
added conditions to show all the FinalRanking page data only if there…

### DIFF
--- a/src/app/finalRanking/final-ranking.component.html
+++ b/src/app/finalRanking/final-ranking.component.html
@@ -1,10 +1,13 @@
 <div class="container">
-  <h1>{{ eventTitle }} on {{ eventDate }}</h1>
-  <!--<h2>{{ eventDate }}</h2>-->
+  <h1>Event Title: {{ eventTitle }}</h1>
+  <h2>Event Date: {{ eventDate }}</h2>
 
   <h3>Top Selected Movie(s):</h3>
   <ng-container *ngIf="finalRankings">
     <div class="content">
+      <div *ngIf="finalRankings.length == 0"> 
+        No rankings submitted. Submit at least one ranking to see the final selection!
+      </div>
       <div *ngIf="topChoices.length > 1">
         There is a {{ topChoices.length }}-way tie!
       </div>
@@ -16,7 +19,7 @@
         <!--<div class="content" *ngIf="finalRankings">
           <app-movie-card [movie]="finalRankings[0]"> </app-movie-card>
         </div>-->
-        <div class="content">
+        <div *ngIf="finalRankings.length > 0" class="content">
           <img
             mat-card-image
             src="{{ finalRankings[0].image }}"
@@ -27,8 +30,8 @@
     </div>
   </ng-container>
 
-  <h3>Final Rankings:</h3>
-  <div class="col-md-12">
+  <h3 *ngIf="finalRankings.length > 0">Final Rankings:</h3>
+  <div *ngIf="finalRankings.length > 0" class="col-md-12">
     <table class="table table-bordered">
       <thead>
         <tr>

--- a/src/app/finalRanking/final-ranking.component.scss
+++ b/src/app/finalRanking/final-ranking.component.scss
@@ -1,5 +1,5 @@
 h1 {
-  padding: 10px 0px;
+  padding-top: 1em;
 }
 
 h3 {

--- a/src/app/finalRanking/final-ranking.component.ts
+++ b/src/app/finalRanking/final-ranking.component.ts
@@ -74,7 +74,10 @@ export class FinalRankingComponent implements OnInit {
         this.id = this.movieEvent.id;
         this.url = this.url + this.id;
       }
-      this.checkPointTie();
+
+      if (this.movieEvent.eventRankings != undefined) {
+        this.checkPointTie();
+      } 
     }
   }
 


### PR DESCRIPTION
… is at least one finalRanking. Also tells user if there is not at least not one finalRanking

# Description
As a User, when no rankings have been submitted for an Event, I want to be able to see feedback on the FinalRankings page telling me why so that I'm not confused as to why no information is showing.

FinalRanking page with no rankings submitted
<img width="794" alt="Screen Shot 2021-09-10 at 9 42 30 PM" src="https://user-images.githubusercontent.com/26866132/132936675-476532b5-2592-4f79-b79f-16afd5bbb1ab.png">

FinalRanking page with rankings submitted
<img width="777" alt="Screen Shot 2021-09-10 at 10 26 38 PM" src="https://user-images.githubusercontent.com/26866132/132937347-7b359a5c-b5eb-44c4-ae1f-11171f7c7e1e.png">

Closes #100 

# Tested
MacOS Big Sur on Chrome browser

# Testing
- [ ] Navigate to Home page from current Intro page by logging in
- [ ] Click on any Event button where the number of "Votes Submitted" has a value of 0.
- [ ] Navigate to the FinalRanking page by changing the URL extension from /ranking to /finalranking
- [ ] View the FinalRanknig page of an Event without rankings submitted
- [ ] Navigate back to the Home page using the back browser navigation or by changing the URL extension from /finalranking to /home
- [ ] Click on any Event button where the number of "Votes Submitted" has a value greater than 0.
- [ ] Navigate to the FinalRanking page by changing the URL extension from /ranking to /finalranking
- [ ] View the FinalRanknig page of an Event with rankings submitted
